### PR TITLE
refactor: prepare shared bot feature infrastructure

### DIFF
--- a/electron/services/bot-events.ts
+++ b/electron/services/bot-events.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from 'node:events';
+import type { ChatMessage } from './twitch-chat';
+
+export interface BotEventUser {
+  id: string;
+  login: string;
+  displayName: string;
+}
+
+export interface BotEventMap {
+  chat_message: ChatMessage;
+  follow: {
+    user: BotEventUser;
+    timestamp: string;
+  };
+  subscription: {
+    user: BotEventUser;
+    tier: string;
+    months: number;
+    isGift: boolean;
+    message?: string | null;
+    timestamp: string;
+  };
+  sub_gift: {
+    user: BotEventUser | null;
+    total: number;
+    tier: string;
+    isAnonymous: boolean;
+    timestamp: string;
+  };
+  cheer: {
+    user: BotEventUser | null;
+    bits: number;
+    message: string;
+    timestamp: string;
+  };
+  raid: {
+    fromChannel: string;
+    fromDisplayName: string;
+    viewers: number;
+    timestamp: string;
+  };
+  stream_online: {
+    timestamp: string;
+  };
+  stream_offline: {
+    timestamp: string;
+  };
+}
+
+type BotEventName = keyof BotEventMap;
+type BotEventHandler<K extends BotEventName> = (payload: BotEventMap[K]) => void;
+
+const emitter = new EventEmitter();
+
+export function emitBotEvent<K extends BotEventName>(
+  event: K,
+  payload: BotEventMap[K],
+): void {
+  emitter.emit(event, payload);
+}
+
+export function onBotEvent<K extends BotEventName>(
+  event: K,
+  handler: BotEventHandler<K>,
+): () => void {
+  const wrapped = handler as (...args: unknown[]) => void;
+  emitter.on(event, wrapped);
+  return () => emitter.off(event, wrapped);
+}

--- a/electron/services/command-engine.ts
+++ b/electron/services/command-engine.ts
@@ -98,7 +98,7 @@ async function canExecuteAsync(
   return isFollower(user.id);
 }
 
-async function buildVariables(
+export async function buildCommandVariables(
   msg: ChatMessage,
   customUsageCount?: number,
 ): Promise<Record<string, string | number>> {
@@ -143,7 +143,7 @@ const BUILTINS: BuiltinSpec[] = [
     cooldown: 5,
     permissions: ['everyone'],
     build: async ({ msg }) => {
-      const v = await buildVariables(msg);
+      const v = await buildCommandVariables(msg);
       return `You are level ${v.level} (${v.exp} EXP) -- ranked #${v.rank}`;
     },
   },
@@ -170,7 +170,7 @@ const BUILTINS: BuiltinSpec[] = [
     cooldown: 5,
     permissions: ['everyone'],
     build: async ({ msg }) => {
-      const v = await buildVariables(msg);
+      const v = await buildCommandVariables(msg);
       return `${v.user}: current watch streak ${v.streak}, best ${v.best_streak}`;
     },
   },
@@ -179,7 +179,7 @@ const BUILTINS: BuiltinSpec[] = [
     cooldown: 5,
     permissions: ['everyone'],
     build: async ({ msg }) => {
-      const v = await buildVariables(msg);
+      const v = await buildCommandVariables(msg);
       return `${v.user}: ${v.watch_time}h total watch time`;
     },
   },
@@ -290,7 +290,7 @@ async function runCustom(name: string, msg: ChatMessage, now: number): Promise<v
   const last = commandCooldowns.get(key) ?? 0;
   if (now < last + row.cooldown_seconds * 1000) return;
 
-  const vars = await buildVariables(msg, row.usage_count + 1);
+  const vars = await buildCommandVariables(msg, row.usage_count + 1);
   const response = interpolate(row.response, vars);
 
   commandCooldowns.set(key, now);

--- a/electron/services/exp-engine.ts
+++ b/electron/services/exp-engine.ts
@@ -5,6 +5,7 @@ import { getDatabase } from './database';
 import { getCurrentTokens } from './twitch-auth';
 import type { ChatMessage } from './twitch-chat';
 import { sendChat } from './twitch-chat';
+import { upsertUser } from './users-repo';
 
 export { computeLevel, expForNextLevel } from '../lib/leveling';
 
@@ -33,20 +34,6 @@ interface ExpSettings {
   levelExponent: number;
   levelupAnnouncement: string;
   levelupAnnounceEnabled: boolean;
-}
-
-interface UserRow {
-  twitch_id: string;
-  username: string;
-  exp: number;
-  level: number;
-  watch_time_minutes: number;
-  messages_sent: number;
-  watch_streak: number;
-  best_watch_streak: number;
-  last_stream_attended: number | null;
-  first_seen: string;
-  last_seen: string;
 }
 
 const MESSAGE_WINDOW_MS = 60_000;
@@ -91,31 +78,6 @@ function loadSettings(): ExpSettings {
     ),
     levelupAnnounceEnabled: num('levelup_announce_enabled', 1) === 1,
   };
-}
-
-function upsertUser(twitchId: string, username: string): UserRow {
-  const db = getDatabase();
-  const now = new Date().toISOString();
-  const existing = db
-    .prepare('SELECT * FROM users WHERE twitch_id = ?')
-    .get(twitchId) as UserRow | undefined;
-
-  if (!existing) {
-    db.prepare(
-      `INSERT INTO users (twitch_id, username, first_seen, last_seen)
-       VALUES (?, ?, ?, ?)`,
-    ).run(twitchId, username, now, now);
-    return db
-      .prepare('SELECT * FROM users WHERE twitch_id = ?')
-      .get(twitchId) as UserRow;
-  }
-
-  db.prepare('UPDATE users SET username = ?, last_seen = ? WHERE twitch_id = ?').run(
-    username,
-    now,
-    twitchId,
-  );
-  return { ...existing, username, last_seen: now };
 }
 
 function logEvent(

--- a/electron/services/settings-service.ts
+++ b/electron/services/settings-service.ts
@@ -19,9 +19,14 @@ export function getSetting(key: string, fallback?: string): string | undefined {
 }
 
 const KNOWN_KEYS = new Set(Object.keys(DEFAULT_SETTINGS));
+const KNOWN_PREFIXES = ['mod_', 'discord_webhook_'] as const;
+
+function isKnownSettingKey(key: string): boolean {
+  return KNOWN_KEYS.has(key) || KNOWN_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
 
 export function updateSetting(key: string, value: unknown): void {
-  if (!KNOWN_KEYS.has(key)) {
+  if (!isKnownSettingKey(key)) {
     throw new Error(`Unknown setting key: ${key}`);
   }
   const stored = normalizeSetting(key, value);

--- a/electron/services/twitch-auth.ts
+++ b/electron/services/twitch-auth.ts
@@ -9,13 +9,20 @@ import { clearCache as clearFollowerCache } from './follower-cache';
 const TWITCH_AUTH_BASE = 'https://id.twitch.tv/oauth2';
 const TWITCH_HELIX = 'https://api.twitch.tv/helix';
 
-const SCOPES = [
+const BASE_SCOPES = [
   'chat:read',
   'chat:edit',
   'channel:read:subscriptions',
   'bits:read',
   'moderator:read:followers',
-];
+] as const;
+
+export const MODERATION_SCOPES = [
+  'moderator:manage:chat_messages',
+  'moderator:manage:banned_users',
+] as const;
+
+const SCOPES = [...BASE_SCOPES, ...MODERATION_SCOPES];
 
 const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
 const OAUTH_CALLBACK_PORT = 42817;
@@ -330,13 +337,23 @@ export function getAuthStatus(): {
   loggedIn: boolean;
   username: string | null;
   channel: string | null;
+  scopes: string[];
 } {
-  if (!currentTokens) return { loggedIn: false, username: null, channel: null };
+  if (!currentTokens) {
+    return { loggedIn: false, username: null, channel: null, scopes: [] };
+  }
   return {
     loggedIn: true,
     username: currentTokens.user.display_name,
     channel: currentTokens.user.login,
+    scopes: currentTokens.scopes,
   };
+}
+
+export function hasScopes(required: readonly string[]): boolean {
+  const tokens = currentTokens;
+  if (!tokens) return false;
+  return required.every((scope) => tokens.scopes.includes(scope));
 }
 
 export async function ensureValidToken(): Promise<StoredTokens | null> {

--- a/electron/services/twitch-chat.ts
+++ b/electron/services/twitch-chat.ts
@@ -1,5 +1,6 @@
 import tmi from 'tmi.js';
 import { broadcast } from '../ipc/broadcast';
+import { emitBotEvent } from './bot-events';
 import { handleChatMessage } from './command-engine';
 import { handleMessageExp } from './exp-engine';
 import {
@@ -15,6 +16,7 @@ import { onChatMessage as streakOnChatMessage } from './streak-tracker';
 export type BotState = 'disconnected' | 'connecting' | 'connected' | 'error';
 
 export interface ChatMessage {
+  id: string | null;
   user: {
     id: string;
     login: string;
@@ -28,6 +30,7 @@ export interface ChatMessage {
     };
   };
   message: string;
+  emotes: Record<string, string[]> | null;
   timestamp: string;
   channel: string;
 }
@@ -96,6 +99,7 @@ export async function connectBot(): Promise<void> {
     if (self) return;
     const msg = normalizeMessage(chan, tags, text);
     console.log(`[chat] <${msg.user.displayName}> ${msg.message}`);
+    emitBotEvent('chat_message', msg);
     broadcast('twitch:chat-message', msg);
     // EXP first: handleMessageExp upserts the users row. streakOnChatMessage
     // writes to viewer_sessions which has a FK to users.twitch_id, so running
@@ -235,8 +239,10 @@ function normalizeMessage(
 ): ChatMessage {
   const badges = tags.badges ?? {};
   return {
+    id: tags.id ?? null,
     channel: channel.replace(/^#/, ''),
     message: text,
+    emotes: (tags.emotes as Record<string, string[]> | undefined) ?? null,
     timestamp: new Date().toISOString(),
     user: {
       id: tags['user-id'] ?? '',

--- a/electron/services/twitch-eventsub.ts
+++ b/electron/services/twitch-eventsub.ts
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { broadcast } from '../ipc/broadcast';
+import { emitBotEvent } from './bot-events';
 import {
   handleCheerExp,
   handleFollowExp,
@@ -298,10 +299,12 @@ function handleNotification(data: EventSubMessage['payload']): void {
   switch (subType) {
     case 'channel.follow': {
       const user = userFromEvent();
-      broadcast('twitch:follow', {
+      const payload = {
         user,
         timestamp: (event.followed_at as string) ?? now,
-      });
+      };
+      emitBotEvent('follow', payload);
+      broadcast('twitch:follow', payload);
       safeExp(() => {
         handleFollowExp(user.id, user.displayName);
         markFollowing(user.id);
@@ -312,13 +315,15 @@ function handleNotification(data: EventSubMessage['payload']): void {
       const user = userFromEvent();
       const tier = String(event.tier ?? '1000');
       const isGift = Boolean(event.is_gift);
-      broadcast('twitch:subscribe', {
+      const payload = {
         user,
         tier,
         months: 1,
         isGift,
         timestamp: now,
-      });
+      };
+      emitBotEvent('subscription', payload);
+      broadcast('twitch:subscribe', payload);
       safeExp(() => handleSubscribeExp(user.id, user.displayName, tier, 1, isGift));
       break;
     }
@@ -327,14 +332,16 @@ function handleNotification(data: EventSubMessage['payload']): void {
       const tier = String(event.tier ?? '1000');
       const months = Number(event.cumulative_months ?? 1);
       const message = event.message as { text?: string } | undefined;
-      broadcast('twitch:subscribe', {
+      const payload = {
         user,
         tier,
         months,
         isGift: false,
         message: message?.text ?? null,
         timestamp: now,
-      });
+      };
+      emitBotEvent('subscription', payload);
+      broadcast('twitch:subscribe', payload);
       safeExp(() => handleSubscribeExp(user.id, user.displayName, tier, months, false));
       break;
     }
@@ -343,13 +350,15 @@ function handleNotification(data: EventSubMessage['payload']): void {
       const user = isAnonymous ? null : userFromEvent();
       const total = Number(event.total ?? 1);
       const tier = String(event.tier ?? '1000');
-      broadcast('twitch:gift-sub', {
+      const payload = {
         user,
         total,
         tier,
         isAnonymous,
         timestamp: now,
-      });
+      };
+      emitBotEvent('sub_gift', payload);
+      broadcast('twitch:gift-sub', payload);
       safeExp(() =>
         handleGiftSubExp(
           user?.id ?? null,
@@ -365,12 +374,14 @@ function handleNotification(data: EventSubMessage['payload']): void {
       const isAnonymous = Boolean(event.is_anonymous);
       const user = isAnonymous ? null : userFromEvent();
       const bits = Number(event.bits ?? 0);
-      broadcast('twitch:cheer', {
+      const payload = {
         user,
         bits,
         message: String(event.message ?? ''),
         timestamp: now,
-      });
+      };
+      emitBotEvent('cheer', payload);
+      broadcast('twitch:cheer', payload);
       safeExp(() =>
         handleCheerExp(user?.id ?? null, user?.displayName ?? null, bits, isAnonymous),
       );
@@ -379,24 +390,30 @@ function handleNotification(data: EventSubMessage['payload']): void {
     case 'channel.raid': {
       const fromChannel = String(event.from_broadcaster_user_login ?? '');
       const viewers = Number(event.viewers ?? 0);
-      broadcast('twitch:raid', {
+      const payload = {
         fromChannel,
         fromDisplayName: String(
           event.from_broadcaster_user_name ?? event.from_broadcaster_user_login ?? '',
         ),
         viewers,
         timestamp: now,
-      });
+      };
+      emitBotEvent('raid', payload);
+      broadcast('twitch:raid', payload);
       safeExp(() => handleRaidExp(viewers, fromChannel));
       break;
     }
     case 'stream.online':
+      emitBotEvent('stream_online', {
+        timestamp: (event.started_at as string) ?? now,
+      });
       broadcast('twitch:stream-online', {
         timestamp: (event.started_at as string) ?? now,
       });
       safeExp(onStreamOnline);
       break;
     case 'stream.offline':
+      emitBotEvent('stream_offline', { timestamp: now });
       broadcast('twitch:stream-offline', { timestamp: now });
       safeExp(onStreamOffline);
       break;

--- a/electron/services/twitch-helix.ts
+++ b/electron/services/twitch-helix.ts
@@ -2,6 +2,8 @@ import { ensureValidToken } from './twitch-auth';
 
 const HELIX = 'https://api.twitch.tv/helix';
 
+type HelixMethod = 'GET' | 'POST' | 'DELETE' | 'PATCH' | 'PUT';
+
 export interface HelixStream {
   id: string;
   user_id: string;
@@ -27,9 +29,13 @@ export interface HelixPage<T> {
   pagination?: { cursor?: string };
 }
 
-async function helixGet<T>(
+export async function helixRequest<T>(
   endpoint: string,
-  query?: Record<string, string | string[] | undefined>,
+  options: {
+    method?: HelixMethod;
+    query?: Record<string, string | string[] | undefined>;
+    body?: unknown;
+  } = {},
 ): Promise<T> {
   const tokens = await ensureValidToken();
   if (!tokens) throw new Error('Not signed in.');
@@ -37,8 +43,8 @@ async function helixGet<T>(
   if (!clientId) throw new Error('TWITCH_CLIENT_ID not set.');
 
   const url = new URL(`${HELIX}${endpoint}`);
-  if (query) {
-    for (const [key, value] of Object.entries(query)) {
+  if (options.query) {
+    for (const [key, value] of Object.entries(options.query)) {
       if (value === undefined) continue;
       if (Array.isArray(value)) {
         for (const v of value) url.searchParams.append(key, v);
@@ -48,18 +54,35 @@ async function helixGet<T>(
     }
   }
 
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${tokens.access_token}`,
+    'Client-Id': clientId,
+  };
+  let body: string | undefined;
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(options.body);
+  }
+
   const res = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${tokens.access_token}`,
-      'Client-Id': clientId,
-    },
+    method: options.method ?? 'GET',
+    headers,
+    body,
   });
 
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`Helix ${endpoint} failed: ${res.status} ${text}`);
   }
+  if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
+}
+
+async function helixGet<T>(
+  endpoint: string,
+  query?: Record<string, string | string[] | undefined>,
+): Promise<T> {
+  return helixRequest<T>(endpoint, { query });
 }
 
 /**

--- a/electron/services/users-repo.ts
+++ b/electron/services/users-repo.ts
@@ -63,6 +63,31 @@ export interface ListUsersResult {
   total: number;
 }
 
+export function upsertUser(twitchId: string, username: string): UserRow {
+  const db = getDatabase();
+  const now = new Date().toISOString();
+  const existing = db
+    .prepare('SELECT * FROM users WHERE twitch_id = ?')
+    .get(twitchId) as UserRow | undefined;
+
+  if (!existing) {
+    db.prepare(
+      `INSERT INTO users (twitch_id, username, first_seen, last_seen)
+       VALUES (?, ?, ?, ?)`,
+    ).run(twitchId, username, now, now);
+    return db
+      .prepare('SELECT * FROM users WHERE twitch_id = ?')
+      .get(twitchId) as UserRow;
+  }
+
+  db.prepare('UPDATE users SET username = ?, last_seen = ? WHERE twitch_id = ?').run(
+    username,
+    now,
+    twitchId,
+  );
+  return { ...existing, username, last_seen: now };
+}
+
 export function listUsers(opts: ListUsersOptions = {}): ListUsersResult {
   const db = getDatabase();
   const sort = opts.sort ?? 'exp';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,7 @@ export interface AuthStatus {
   loggedIn: boolean;
   username: string | null;
   channel: string | null;
+  scopes: string[];
 }
 
 export type BotState = 'disconnected' | 'connecting' | 'connected' | 'error';
@@ -92,6 +93,7 @@ export interface ActivityData {
 }
 
 export interface ChatMessagePayload {
+  id: string | null;
   user: {
     id: string;
     login: string;
@@ -105,6 +107,7 @@ export interface ChatMessagePayload {
     };
   };
   message: string;
+  emotes: Record<string, string[]> | null;
   timestamp: string;
   channel: string;
 }

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -31,7 +31,12 @@ interface AppState {
   dismissNotice: () => void;
 }
 
-const defaultAuth: AuthStatus = { loggedIn: false, username: null, channel: null };
+const defaultAuth: AuthStatus = {
+  loggedIn: false,
+  username: null,
+  channel: null,
+  scopes: [],
+};
 const defaultBot: BotStatus = { state: 'disconnected', error: null };
 
 export const useAppStore = create<AppState>((set, get) => ({


### PR DESCRIPTION
Closes #7\n\n## Summary\n- move user upsert into the users repository for reuse before moderation/EXP pipelines\n- export command variable resolution for timers and automations\n- add Twitch message IDs/emotes to normalized chat messages\n- add an internal bot event bus and publish current chat/EventSub events to it\n- extend auth scopes, settings prefix handling, and the existing Helix wrapper for upcoming feature modules\n\n## Validation\n- npm run typecheck\n- npm test