### PR TITLE
feat(timers): add recurring chat timers

### DIFF
--- a/electron/db/schema.sql
+++ b/electron/db/schema.sql
@@ -71,3 +71,15 @@ CREATE TABLE IF NOT EXISTS settings (
   key    TEXT PRIMARY KEY,
   value  TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS timers (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  name              TEXT NOT NULL,
+  message           TEXT NOT NULL,
+  interval_seconds  INTEGER NOT NULL DEFAULT 300,
+  min_chat_lines    INTEGER NOT NULL DEFAULT 0,
+  enabled           INTEGER NOT NULL DEFAULT 1,
+  last_fired_at     INTEGER,
+  created_at        INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at        INTEGER NOT NULL DEFAULT (unixepoch())
+);

--- a/electron/ipc/timers.ts
+++ b/electron/ipc/timers.ts
@@ -1,0 +1,61 @@
+import { ipcMain } from 'electron';
+import {
+  createTimer,
+  deleteTimer,
+  listTimers,
+  toggleTimer,
+  updateTimer,
+  type TimerInput,
+  type TimerUpdate,
+} from '../services/timers-service';
+
+type IpcResult<T> = { success: true; data: T } | { success: false; error: string };
+
+const ok = <T>(data: T): IpcResult<T> => ({ success: true, data });
+const fail = (err: unknown): IpcResult<never> => ({
+  success: false,
+  error: err instanceof Error ? err.message : String(err),
+});
+
+export function registerTimerHandlers(): void {
+  ipcMain.handle('timers:list', () => {
+    try {
+      return ok(listTimers());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('timers:create', (_event, input: TimerInput) => {
+    try {
+      return ok(createTimer(input));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('timers:update', (_event, update: TimerUpdate) => {
+    try {
+      return ok(updateTimer(update));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('timers:delete', (_event, id: number) => {
+    try {
+      deleteTimer(id);
+      return ok(null);
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('timers:toggle', (_event, id: number) => {
+    try {
+      return ok(toggleTimer(id));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@ import { registerDiagnosticsHandlers } from './ipc/diagnostics';
 import { registerFeedHandlers } from './ipc/feed';
 import { registerSessionHandlers } from './ipc/sessions';
 import { registerSettingsHandlers } from './ipc/settings';
+import { registerTimerHandlers } from './ipc/timers';
 import { registerUserHandlers } from './ipc/users';
 import { registerWindowHandlers } from './ipc/window';
 import { closeDatabase, initDatabase } from './services/database';
@@ -115,6 +116,7 @@ app.whenReady().then(async () => {
   registerAuthHandlers();
   registerBotHandlers();
   registerCommandHandlers();
+  registerTimerHandlers();
   registerSessionHandlers();
   registerUserHandlers();
   registerAnalyticsHandlers();

--- a/electron/services/timers-service.ts
+++ b/electron/services/timers-service.ts
@@ -1,4 +1,8 @@
+import { buildCommandVariables, interpolate } from './command-engine';
 import { getDatabase } from './database';
+import { onBotEvent } from './bot-events';
+import { getCurrentTokens } from './twitch-auth';
+import { getBotState, sendChat, type ChatMessage } from './twitch-chat';
 
 export interface TimerRow {
   id: number;
@@ -41,6 +45,11 @@ export interface TimerUpdate {
   enabled?: boolean;
 }
 
+const TICK_MS = 15_000;
+const MAX_CHAT_LENGTH = 480;
+
+let timerLoop: NodeJS.Timeout | null = null;
+let unsubscribeChat: (() => void) | null = null;
 const chatLinesSinceFire = new Map<number, number>();
 
 export function listTimers(): TimerRow[] {
@@ -106,12 +115,103 @@ export function toggleTimer(id: number): TimerRow {
   return updateTimer({ id, enabled: !existing.enabled });
 }
 
+export function startTimerEngine(): void {
+  if (!unsubscribeChat) {
+    unsubscribeChat = onBotEvent('chat_message', () => {
+      const rows = getEnabledTimerIds();
+      for (const id of rows) {
+        chatLinesSinceFire.set(id, (chatLinesSinceFire.get(id) ?? 0) + 1);
+      }
+    });
+  }
+  if (timerLoop) return;
+  timerLoop = setInterval(() => {
+    void tickTimers().catch((err) => console.error('[timers] tick failed:', err));
+  }, TICK_MS);
+}
+
+export function stopTimerEngine(): void {
+  if (timerLoop) {
+    clearInterval(timerLoop);
+    timerLoop = null;
+  }
+  if (unsubscribeChat) {
+    unsubscribeChat();
+    unsubscribeChat = null;
+  }
+  chatLinesSinceFire.clear();
+}
+
+async function tickTimers(): Promise<void> {
+  if (getBotState().state !== 'connected') return;
+
+  const timers = getDatabase()
+    .prepare('SELECT * FROM timers WHERE enabled = 1 ORDER BY id')
+    .all() as TimerDbRow[];
+  const now = Math.floor(Date.now() / 1000);
+
+  for (const row of timers) {
+    const timer = rowToTimer(row);
+    if (!timer.message.trim()) continue;
+    const last = timer.last_fired_at ?? 0;
+    if (now - last < timer.interval_seconds) continue;
+    const lines = chatLinesSinceFire.get(timer.id) ?? 0;
+    if (lines < timer.min_chat_lines) continue;
+
+    const message = await resolveTimerMessage(timer.message);
+    if (!message.trim()) continue;
+
+    await sendChat(
+      message.length > MAX_CHAT_LENGTH
+        ? `${message.slice(0, MAX_CHAT_LENGTH - 1)}...`
+        : message,
+    );
+    getDatabase()
+      .prepare('UPDATE timers SET last_fired_at = ?, updated_at = unixepoch() WHERE id = ?')
+      .run(now, timer.id);
+    chatLinesSinceFire.set(timer.id, 0);
+  }
+}
+
+async function resolveTimerMessage(template: string): Promise<string> {
+  const tokens = getCurrentTokens();
+  if (!tokens) return template;
+  const msg: ChatMessage = {
+    id: null,
+    channel: tokens.user.login,
+    message: '',
+    emotes: null,
+    timestamp: new Date().toISOString(),
+    user: {
+      id: tokens.user.id,
+      login: tokens.user.login,
+      displayName: tokens.user.display_name,
+      color: null,
+      roles: {
+        broadcaster: true,
+        moderator: true,
+        vip: false,
+        subscriber: false,
+      },
+    },
+  };
+  const vars = await buildCommandVariables(msg);
+  return interpolate(template, vars);
+}
+
 function getTimer(id: number): TimerRow {
   const row = getDatabase()
     .prepare('SELECT * FROM timers WHERE id = ?')
     .get(id) as TimerDbRow | undefined;
   if (!row) throw new Error(`Timer ${id} not found.`);
   return rowToTimer(row);
+}
+
+function getEnabledTimerIds(): number[] {
+  const rows = getDatabase()
+    .prepare('SELECT id FROM timers WHERE enabled = 1')
+    .all() as { id: number }[];
+  return rows.map((row) => row.id);
 }
 
 function normalizeTimerInput(input: TimerInput): Required<TimerInput> {

--- a/electron/services/timers-service.ts
+++ b/electron/services/timers-service.ts
@@ -1,0 +1,147 @@
+import { getDatabase } from './database';
+
+export interface TimerRow {
+  id: number;
+  name: string;
+  message: string;
+  interval_seconds: number;
+  min_chat_lines: number;
+  enabled: boolean;
+  last_fired_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface TimerDbRow {
+  id: number;
+  name: string;
+  message: string;
+  interval_seconds: number;
+  min_chat_lines: number;
+  enabled: number;
+  last_fired_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface TimerInput {
+  name: string;
+  message: string;
+  interval_seconds?: number;
+  min_chat_lines?: number;
+  enabled?: boolean;
+}
+
+export interface TimerUpdate {
+  id: number;
+  name?: string;
+  message?: string;
+  interval_seconds?: number;
+  min_chat_lines?: number;
+  enabled?: boolean;
+}
+
+const chatLinesSinceFire = new Map<number, number>();
+
+export function listTimers(): TimerRow[] {
+  const rows = getDatabase()
+    .prepare('SELECT * FROM timers ORDER BY name COLLATE NOCASE')
+    .all() as TimerDbRow[];
+  return rows.map(rowToTimer);
+}
+
+export function createTimer(input: TimerInput): TimerRow {
+  const normalized = normalizeTimerInput(input);
+  const info = getDatabase()
+    .prepare(
+      `INSERT INTO timers (name, message, interval_seconds, min_chat_lines, enabled)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      normalized.name,
+      normalized.message,
+      normalized.interval_seconds,
+      normalized.min_chat_lines,
+      normalized.enabled ? 1 : 0,
+    );
+  return getTimer(Number(info.lastInsertRowid));
+}
+
+export function updateTimer(update: TimerUpdate): TimerRow {
+  const existing = getTimer(update.id);
+  const normalized = normalizeTimerInput({
+    name: update.name ?? existing.name,
+    message: update.message ?? existing.message,
+    interval_seconds: update.interval_seconds ?? existing.interval_seconds,
+    min_chat_lines: update.min_chat_lines ?? existing.min_chat_lines,
+    enabled: update.enabled ?? existing.enabled,
+  });
+
+  getDatabase()
+    .prepare(
+      `UPDATE timers
+       SET name = ?, message = ?, interval_seconds = ?, min_chat_lines = ?,
+           enabled = ?, updated_at = unixepoch()
+       WHERE id = ?`,
+    )
+    .run(
+      normalized.name,
+      normalized.message,
+      normalized.interval_seconds,
+      normalized.min_chat_lines,
+      normalized.enabled ? 1 : 0,
+      update.id,
+    );
+  return getTimer(update.id);
+}
+
+export function deleteTimer(id: number): void {
+  const info = getDatabase().prepare('DELETE FROM timers WHERE id = ?').run(id);
+  if (info.changes === 0) throw new Error(`Timer ${id} not found.`);
+  chatLinesSinceFire.delete(id);
+}
+
+export function toggleTimer(id: number): TimerRow {
+  const existing = getTimer(id);
+  return updateTimer({ id, enabled: !existing.enabled });
+}
+
+function getTimer(id: number): TimerRow {
+  const row = getDatabase()
+    .prepare('SELECT * FROM timers WHERE id = ?')
+    .get(id) as TimerDbRow | undefined;
+  if (!row) throw new Error(`Timer ${id} not found.`);
+  return rowToTimer(row);
+}
+
+function normalizeTimerInput(input: TimerInput): Required<TimerInput> {
+  const name = input.name.trim();
+  if (!name) throw new Error('Timer name cannot be empty.');
+  const message = input.message.trim();
+  if (!message) throw new Error('Timer message cannot be empty.');
+
+  const interval = input.interval_seconds ?? 300;
+  if (!Number.isInteger(interval) || interval < 15) {
+    throw new Error('Timer interval must be at least 15 seconds.');
+  }
+
+  const minChatLines = input.min_chat_lines ?? 0;
+  if (!Number.isInteger(minChatLines) || minChatLines < 0) {
+    throw new Error('Minimum chat lines must be a non-negative integer.');
+  }
+
+  return {
+    name,
+    message,
+    interval_seconds: interval,
+    min_chat_lines: minChatLines,
+    enabled: input.enabled ?? true,
+  };
+}
+
+function rowToTimer(row: TimerDbRow): TimerRow {
+  return {
+    ...row,
+    enabled: row.enabled === 1,
+  };
+}

--- a/electron/services/twitch-chat.ts
+++ b/electron/services/twitch-chat.ts
@@ -8,6 +8,7 @@ import {
   onStreamOffline,
   onStreamOnline,
 } from './streak-tracker';
+import { startTimerEngine, stopTimerEngine } from './timers-service';
 import { ensureValidToken, getCurrentTokens } from './twitch-auth';
 import { connectEventSub, disconnectEventSub } from './twitch-eventsub';
 import { getCurrentStream } from './twitch-helix';
@@ -88,10 +89,12 @@ export async function connectBot(): Promise<void> {
   client.on('connected', (addr, port) => {
     console.log(`[chat] connected to ${addr}:${port} as ${channel}`);
     setState('connected');
+    startTimerEngine();
   });
 
   client.on('disconnected', (reason) => {
     console.log(`[chat] disconnected: ${reason ?? 'unknown'}`);
+    stopTimerEngine();
     if (state !== 'error') setState('disconnected', reason || null);
   });
 
@@ -220,6 +223,7 @@ async function probeStreamState(broadcasterId: string): Promise<void> {
 }
 
 async function safeDestroy(): Promise<void> {
+  stopTimerEngine();
   // Clear pending sends — they would error out anyway once disconnected.
   sendQueue.length = 0;
   if (!client) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,13 @@ import { Loyalty } from './pages/Loyalty';
 import { Popout } from './pages/Popout';
 import { Settings as SettingsPage } from './pages/Settings';
 import { SignIn } from './pages/SignIn';
+import { Timers } from './pages/Timers';
 import { useAppStore } from './stores/useAppStore';
 
 const PAGE_TITLES: Record<string, string> = {
   '/': 'Dashboard',
   '/commands': 'Commands',
+  '/timers': 'Timers',
   '/loyalty': 'Loyalty',
   '/analytics': 'Analytics',
   '/settings': 'Settings',
@@ -72,6 +74,7 @@ function InnerRoutes() {
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/commands" element={<Commands />} />
+          <Route path="/timers" element={<Timers />} />
           <Route path="/loyalty" element={<Loyalty />} />
           <Route path="/analytics" element={<Analytics />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -31,6 +31,15 @@ export function TerminalIcon(props: IconProps) {
   );
 }
 
+export function ClockIcon(props: IconProps) {
+  return (
+    <svg {...baseProps} {...props}>
+      <circle cx="12" cy="12" r="9" />
+      <polyline points="12 7 12 12 15.5 14" />
+    </svg>
+  );
+}
+
 export function TrophyIcon(props: IconProps) {
   return (
     <svg {...baseProps} {...props}>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { useAppStore } from '../stores/useAppStore';
 import {
   BarChartIcon,
+  ClockIcon,
   GearIcon,
   HomeIcon,
   TerminalIcon,
@@ -11,6 +12,7 @@ import {
 const NAV = [
   { to: '/', label: 'Dashboard', icon: HomeIcon, end: true },
   { to: '/commands', label: 'Commands', icon: TerminalIcon, end: false },
+  { to: '/timers', label: 'Timers', icon: ClockIcon, end: false },
   { to: '/loyalty', label: 'Loyalty', icon: TrophyIcon, end: false },
   { to: '/analytics', label: 'Analytics', icon: BarChartIcon, end: false },
   { to: '/settings', label: 'Settings', icon: GearIcon, end: false },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,18 @@ export interface Command {
   created_at: string;
 }
 
+export interface Timer {
+  id: number;
+  name: string;
+  message: string;
+  interval_seconds: number;
+  min_chat_lines: number;
+  enabled: boolean;
+  last_fired_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
 export interface UserRow {
   twitch_id: string;
   username: string;

--- a/src/pages/Timers.tsx
+++ b/src/pages/Timers.tsx
@@ -1,0 +1,425 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useConfirm } from '../components/ConfirmProvider';
+import { Modal } from '../components/Modal';
+import { PlusIcon, TrashIcon } from '../components/Icons';
+import { SkeletonRows } from '../components/Skeleton';
+import { invoke, tryInvoke } from '../lib/ipc';
+import type { Timer } from '../lib/types';
+
+const VARIABLES = [
+  '{user}',
+  '{level}',
+  '{exp}',
+  '{watch_time}',
+  '{streak}',
+  '{best_streak}',
+  '{messages}',
+  '{rank}',
+  '{channel}',
+  '{uptime}',
+  '{count}',
+];
+
+const INTERVAL_PRESETS = [
+  { label: '5m', seconds: 300 },
+  { label: '10m', seconds: 600 },
+  { label: '15m', seconds: 900 },
+  { label: '30m', seconds: 1800 },
+  { label: '60m', seconds: 3600 },
+];
+
+interface EditorState {
+  mode: 'create' | 'edit';
+  timer?: Timer;
+}
+
+export function Timers() {
+  const confirm = useConfirm();
+  const [timers, setTimers] = useState<Timer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editor, setEditor] = useState<EditorState | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const res = await tryInvoke<Timer[]>('timers:list');
+    if (res.success) setTimers(res.data);
+    else setError(res.error);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onSave = async (input: {
+    id?: number;
+    name: string;
+    message: string;
+    interval_seconds: number;
+    min_chat_lines: number;
+    enabled: boolean;
+  }) => {
+    setError(null);
+    try {
+      if (input.id !== undefined) {
+        await invoke('timers:update', input);
+      } else {
+        await invoke('timers:create', input);
+      }
+      setEditor(null);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    }
+  };
+
+  const onToggle = async (timer: Timer) => {
+    try {
+      await invoke('timers:toggle', timer.id);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Toggle failed.');
+    }
+  };
+
+  const onDelete = async (timer: Timer) => {
+    const confirmed = await confirm({
+      title: 'Delete timer',
+      message: (
+        <>
+          Permanently delete <span className="font-mono text-text">{timer.name}</span>?
+        </>
+      ),
+      confirmLabel: 'Delete',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
+    try {
+      await invoke('timers:delete', timer.id);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.');
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-text">
+            Timers
+          </h2>
+          <p className="text-xs text-text-dim">
+            Recurring chat messages that respect interval and chat activity gates.
+          </p>
+        </div>
+        <button
+          onClick={() => setEditor({ mode: 'create' })}
+          className="flex items-center gap-2 border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20"
+        >
+          <PlusIcon width={14} height={14} />
+          Add Timer
+        </button>
+      </div>
+
+      {error && (
+        <div className="border border-offline/40 bg-offline/10 px-3 py-2 text-xs text-offline">
+          {error}
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto border border-border bg-bg-panel">
+        {loading ? (
+          <SkeletonRows
+            rows={6}
+            columns={[
+              { width: 140 },
+              { width: 320 },
+              { width: 90, align: 'right' },
+              { width: 100, align: 'right' },
+              { width: 120, align: 'right' },
+              { width: 60, align: 'center' },
+              { width: 30 },
+            ]}
+          />
+        ) : timers.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+            <p className="text-sm text-text">No timers yet.</p>
+            <p className="text-xs text-text-dim">
+              Click <span className="font-mono">Add Timer</span> to schedule one.
+            </p>
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-bg-elev text-[10px] uppercase tracking-wider text-text-dim">
+              <tr>
+                <th className="px-4 py-2 text-left font-normal">Name</th>
+                <th className="px-4 py-2 text-left font-normal">Message</th>
+                <th className="px-4 py-2 text-right font-normal">Interval</th>
+                <th className="px-4 py-2 text-right font-normal">Chat lines</th>
+                <th className="px-4 py-2 text-right font-normal">Last fired</th>
+                <th className="px-4 py-2 text-center font-normal">On</th>
+                <th className="px-4 py-2 text-right font-normal"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {timers.map((timer) => (
+                <tr
+                  key={timer.id}
+                  className="cursor-pointer border-t border-border hover:bg-bg-hover"
+                  onClick={() => setEditor({ mode: 'edit', timer })}
+                >
+                  <td className="px-4 py-2 font-mono text-text">{timer.name}</td>
+                  <td className="max-w-[420px] truncate px-4 py-2 text-text-muted">
+                    {timer.message}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-xs text-text-muted">
+                    {formatInterval(timer.interval_seconds)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-xs text-text-muted">
+                    {timer.min_chat_lines}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-xs text-text-muted">
+                    {formatLastFired(timer.last_fired_at)}
+                  </td>
+                  <td
+                    className="px-4 py-2 text-center"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      onClick={() => {
+                        void onToggle(timer);
+                      }}
+                      className={`relative h-4 w-8 border transition-colors ${
+                        timer.enabled
+                          ? 'border-accent bg-accent/30'
+                          : 'border-border bg-bg'
+                      }`}
+                      aria-pressed={timer.enabled}
+                    >
+                      <span
+                        className={`absolute top-0.5 h-2.5 w-2.5 transition-all ${
+                          timer.enabled
+                            ? 'left-[18px] bg-accent'
+                            : 'left-0.5 bg-text-dim'
+                        }`}
+                      />
+                    </button>
+                  </td>
+                  <td
+                    className="px-4 py-2 text-right"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      onClick={() => {
+                        void onDelete(timer);
+                      }}
+                      className="text-text-dim hover:text-offline"
+                      aria-label={`Delete ${timer.name}`}
+                    >
+                      <TrashIcon width={14} height={14} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {editor && (
+        <TimerEditor
+          mode={editor.mode}
+          timer={editor.timer}
+          onClose={() => setEditor(null)}
+          onSave={onSave}
+        />
+      )}
+    </div>
+  );
+}
+
+function TimerEditor({
+  mode,
+  timer,
+  onClose,
+  onSave,
+}: {
+  mode: 'create' | 'edit';
+  timer?: Timer;
+  onClose: () => void;
+  onSave: (input: {
+    id?: number;
+    name: string;
+    message: string;
+    interval_seconds: number;
+    min_chat_lines: number;
+    enabled: boolean;
+  }) => Promise<void>;
+}) {
+  const [name, setName] = useState(timer?.name ?? '');
+  const [message, setMessage] = useState(timer?.message ?? '');
+  const [interval, setIntervalSeconds] = useState(timer?.interval_seconds ?? 300);
+  const [minChatLines, setMinChatLines] = useState(timer?.min_chat_lines ?? 0);
+  const [enabled, setEnabled] = useState(timer?.enabled ?? true);
+  const [saving, setSaving] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setLocalError(null);
+    setSaving(true);
+    try {
+      await onSave({
+        id: timer?.id,
+        name,
+        message,
+        interval_seconds: interval,
+        min_chat_lines: minChatLines,
+        enabled,
+      });
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const insertVariable = (v: string) => {
+    setMessage((prev) => prev + v);
+  };
+
+  return (
+    <Modal
+      title={mode === 'create' ? 'Add Timer' : `Edit ${timer?.name}`}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            onClick={onClose}
+            className="border border-border bg-bg-panel px-3 py-1.5 text-xs uppercase tracking-wider text-text-muted hover:bg-bg-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => {
+              void handleSave();
+            }}
+            disabled={saving || !name.trim() || !message.trim()}
+            className="border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20 disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {localError && (
+          <div className="border border-offline/40 bg-offline/10 px-3 py-2 text-xs text-offline">
+            {localError}
+          </div>
+        )}
+
+        <div>
+          <label className="mb-1 block text-xs text-text-muted">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Discord promo"
+            className="w-full border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs text-text-muted">Message</label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={3}
+            placeholder="Join the Discord, {user}: example.com"
+            className="w-full resize-none border border-border bg-bg px-2.5 py-1.5 font-mono text-sm text-text outline-none focus:border-accent"
+          />
+          <div className="mt-2 flex flex-wrap gap-1">
+            {VARIABLES.map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => insertVariable(v)}
+                className="border border-border bg-bg px-1.5 py-0.5 font-mono text-[10px] text-text-muted hover:border-accent/50 hover:text-accent"
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs text-text-muted">Interval</label>
+          <div className="flex flex-wrap gap-1.5">
+            {INTERVAL_PRESETS.map((preset) => {
+              const active = interval === preset.seconds;
+              return (
+                <button
+                  key={preset.seconds}
+                  type="button"
+                  onClick={() => setIntervalSeconds(preset.seconds)}
+                  className={`border px-2 py-1 font-mono text-[10px] uppercase tracking-wider transition-colors ${
+                    active
+                      ? 'border-accent bg-accent/10 text-accent'
+                      : 'border-border bg-bg text-text-muted hover:bg-bg-hover'
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              );
+            })}
+            <input
+              type="number"
+              min={15}
+              value={interval}
+              onChange={(e) => setIntervalSeconds(Number(e.target.value))}
+              className="w-24 border border-border bg-bg px-2 py-1 font-mono text-xs text-text outline-none focus:border-accent"
+              aria-label="Custom interval in seconds"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="mb-1 block text-xs text-text-muted">
+              Min chat lines
+            </label>
+            <input
+              type="number"
+              min={0}
+              value={minChatLines}
+              onChange={(e) => setMinChatLines(Number(e.target.value))}
+              className="w-full border border-border bg-bg px-2.5 py-1.5 font-mono text-sm text-text outline-none focus:border-accent"
+            />
+          </div>
+          <div className="flex items-end">
+            <label className="flex items-center gap-2 text-xs text-text-muted">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                className="h-3.5 w-3.5 accent-accent"
+              />
+              Enabled
+            </label>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function formatInterval(seconds: number): string {
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+function formatLastFired(timestamp: number | null): string {
+  if (!timestamp) return 'never';
+  return new Date(timestamp * 1000).toLocaleString();
+}


### PR DESCRIPTION
Closes #8\n\n## Summary\n- add timers table, IPC handlers, and timer CRUD service\n- start/stop a 15-second timer loop with the bot chat lifecycle\n- track chat-line activity gates per timer and reuse command variable interpolation before sending\n- add the Timers sidebar route and management UI with create/edit/delete/toggle controls\n\n## Validation\n- npm run typecheck\n- npm test\n- npm run build\n- npm run lint\n- manual testing by user