### PR TITLE
feat(auto): add automation event triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Chat commands, EXP and levels, watch streaks, a live event feed, and a dashboard
 ## What it does
 
 - **Runs your bot.** Connects to your Twitch chat and responds to commands — custom ones you write plus 5 built-ins (`!rank`, `!leaderboard`, `!streak`, `!watchtime`, `!commands`).
+- **Sends recurring timers.** Schedule chat reminders that wait for both time and chat activity before posting.
+- **Moderates chat.** Optional filters catch links, caps, emote spam, repeated messages, and symbol spam, then escalate through Helix moderation actions.
+- **Automates events.** Trigger chat messages, sounds, Discord webhooks, timeouts, EXP bonuses, and delays from follows, subs, cheers, raids, and stream state.
 - **Tracks loyalty.** Every viewer who chats accrues EXP, levels up, and builds a watch streak across streams.
 - **Shows you what happened.** A live feed mirrors chat + every follow, sub, cheer, raid, and stream event as they happen. Historical data is charted on the Analytics page.
 - **Keeps your data yours.** Everything lives in a single SQLite file on your machine. You can export it at any time. Zero telemetry, zero third-party servers.
@@ -22,6 +25,18 @@ Chat commands, EXP and levels, watch streaks, a live event feed, and a dashboard
 Custom responses with variables (`{user}`, `{level}`, `{watch_time}`, …), per-command cooldowns, and set-based permissions (any mix of `everyone`, `follower`, `vip`, `subscriber`, `moderator`).
 
 ![Commands](docs/screenshots/02-commands.png)
+
+### Timers
+
+Recurring chat messages with the same variable templates as commands. Each timer can require a minimum number of chat lines since it last fired, so the bot can stay quiet when chat is quiet.
+
+### Moderation
+
+Configurable automatic moderation for links, caps, emotes, repeated messages, and symbol spam. Actions use Twitch Helix moderation endpoints, not deprecated IRC commands, with warning logs and permitted-user controls.
+
+### Automations
+
+Event triggers for follows, subscriptions, gift subs, cheers, raids, stream online, and stream offline. Add optional conditions, cooldowns, and ordered actions: chat messages, sounds, Discord webhook posts, user timeouts, bonus EXP, and short delays.
 
 ### Loyalty & leaderboard
 
@@ -96,6 +111,8 @@ Everything below is editable in-app from the Settings page. Changes apply live �
 | `global_cooldown_seconds` | 2 | Minimum time between any two command invocations. |
 | `level_base` / `level_exponent` | 100 / 1.5 | Level formula: `floor(base × level^exponent)` EXP to level up. |
 | `levelup_announcement` | `{user} just reached level {level}!` | Template. Can be disabled entirely. |
+| `mod_*` | varies | Moderation rule toggles, thresholds, exemptions, permit duration, and escalation timeouts. |
+| `discord_webhook_*` | empty | Named Discord webhook URLs used by Automations. |
 
 ---
 
@@ -106,8 +123,9 @@ Everything below is editable in-app from the Settings page. Changes apply live �
 
 ```powershell
 npm run typecheck          # strict TypeScript (main + renderer)
-npm test                   # Vitest unit tests (45 assertions)
-npm run test:ipc           # Service-layer integration tests (53 assertions)
+npm test                   # Vitest unit tests
+npm run lint               # ESLint
+npm run test:ipc           # Service-layer integration tests
 npm run build              # Production build
 ```
 
@@ -158,7 +176,7 @@ scripts/      Dev utilities (seed, inspect, test runners, screenshot capture)
 
 - **No server.** Chat goes over `tmi.js`; events come via Twitch's EventSub WebSocket; metadata queries hit Helix. The app is only ever a client.
 - **Secrets encrypted at rest.** OAuth tokens + application credentials use Electron's `safeStorage` (backed by Windows DPAPI / macOS Keychain / libsecret on Linux). No plaintext credentials touch disk.
-- **Resilience:** follower lookups cached 15 min; EventSub reconnect silently backfills missed followers via Helix; chat sends rate-limited through an async queue (1 msg/sec, drops oldest on overflow); Helix `/streams` probe on bot connect recovers state across app restarts; ErrorBoundary wraps the renderer + logs crashes to the main process.
+- **Resilience:** follower lookups cached 15 min; EventSub reconnect silently backfills missed followers via Helix; chat sends rate-limited through an async queue (1 msg/sec, drops oldest on overflow); Helix calls use a shared rate limiter; Helix `/streams` probe on bot connect recovers state across app restarts; ErrorBoundary wraps the renderer + logs crashes to the main process.
 - **Content Security Policy** locked down for packaged builds. Only `id.twitch.tv`, `api.twitch.tv`, and the two Twitch WebSockets are in `connect-src`.
 - **Keyboard:** `Alt+1` … `Alt+5` jump between pages (dev convenience, always on).
 

--- a/electron/db/schema.sql
+++ b/electron/db/schema.sql
@@ -104,3 +104,16 @@ CREATE TABLE IF NOT EXISTS mod_permitted_users (
   username    TEXT NOT NULL,
   created_at  INTEGER NOT NULL DEFAULT (unixepoch())
 );
+
+CREATE TABLE IF NOT EXISTS automations (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  name               TEXT NOT NULL,
+  enabled            INTEGER NOT NULL DEFAULT 1,
+  event_type         TEXT NOT NULL,
+  conditions         TEXT NOT NULL DEFAULT '[]',
+  actions            TEXT NOT NULL DEFAULT '[]',
+  cooldown_seconds   INTEGER NOT NULL DEFAULT 0,
+  last_triggered_at  INTEGER,
+  created_at         INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at         INTEGER NOT NULL DEFAULT (unixepoch())
+);

--- a/electron/ipc/automations.ts
+++ b/electron/ipc/automations.ts
@@ -1,0 +1,177 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import {
+  addSoundFromDialog,
+  createAutomation,
+  deleteAutomation,
+  deleteSound,
+  getSoundsDirectory,
+  listAutomations,
+  listSounds,
+  testAutomation,
+  toggleAutomation,
+  updateAutomation,
+  type AutomationInput,
+  type AutomationUpdate,
+} from '../services/automation-engine';
+import { deleteSetting, getAllSettings, updateSetting } from '../services/settings-service';
+
+type IpcResult<T> = { success: true; data: T } | { success: false; error: string };
+
+const ok = <T>(data: T): IpcResult<T> => ({ success: true, data });
+const fail = (err: unknown): IpcResult<never> => ({
+  success: false,
+  error: err instanceof Error ? err.message : String(err),
+});
+
+export function registerAutomationHandlers(): void {
+  ipcMain.handle('automations:list', () => {
+    try {
+      return ok(listAutomations());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('automations:create', (_event, input: AutomationInput) => {
+    try {
+      return ok(createAutomation(input));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('automations:update', (_event, update: AutomationUpdate) => {
+    try {
+      return ok(updateAutomation(update));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('automations:delete', (_event, id: number) => {
+    try {
+      deleteAutomation(id);
+      return ok(null);
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('automations:toggle', (_event, id: number) => {
+    try {
+      return ok(toggleAutomation(id));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('automations:test', (_event, input: AutomationInput) => {
+    try {
+      return ok(testAutomation(input));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('discord-webhooks:list', () => {
+    try {
+      return ok(listDiscordWebhooks());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle(
+    'discord-webhooks:save',
+    (_event, payload: { key: string; url: string }) => {
+      try {
+        const key = normalizeWebhookKey(payload.key);
+        updateSetting(`discord_webhook_${key}`, payload.url);
+        return ok(listDiscordWebhooks());
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  ipcMain.handle('discord-webhooks:delete', (_event, key: string) => {
+    try {
+      deleteSetting(`discord_webhook_${normalizeWebhookKey(key)}`);
+      return ok(listDiscordWebhooks());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle(
+    'discord-webhooks:test',
+    async (_event, payload: { key: string; url?: string }) => {
+      try {
+        const url =
+          payload.url ??
+          getAllSettings()[`discord_webhook_${normalizeWebhookKey(payload.key)}`];
+        if (!url) throw new Error('Webhook URL is empty.');
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: 'TwitchBot webhook test' }),
+        });
+        if (!res.ok) {
+          throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+        }
+        return ok(null);
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  ipcMain.handle('sounds:list', async () => {
+    try {
+      return ok({
+        directory: getSoundsDirectory(),
+        files: await listSounds(),
+      });
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('sounds:add', async (event) => {
+    try {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      return ok(await addSoundFromDialog(window));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('sounds:delete', async (_event, name: string) => {
+    try {
+      await deleteSound(name);
+      return ok(await listSounds());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+}
+
+function listDiscordWebhooks(): Array<{ key: string; url: string }> {
+  return Object.entries(getAllSettings())
+    .filter(([key]) => key.startsWith('discord_webhook_'))
+    .map(([key, url]) => ({
+      key: key.replace(/^discord_webhook_/, ''),
+      url,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function normalizeWebhookKey(key: string): string {
+  const normalized = key
+    .trim()
+    .toLowerCase()
+    .replace(/^discord_webhook_/, '')
+    .replace(/[^a-z0-9_-]/g, '_');
+  if (!normalized) throw new Error('Webhook name is required.');
+  return normalized;
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import path from 'node:path';
 import { registerAnalyticsHandlers } from './ipc/analytics';
 import { registerAuthHandlers } from './ipc/auth';
+import { registerAutomationHandlers } from './ipc/automations';
 import { registerBotHandlers } from './ipc/bot';
 import { registerCommandHandlers } from './ipc/commands';
 import { registerCredentialHandlers } from './ipc/credentials';
@@ -17,6 +18,7 @@ import { registerTimerHandlers } from './ipc/timers';
 import { registerUserHandlers } from './ipc/users';
 import { registerWindowHandlers } from './ipc/window';
 import { closeDatabase, initDatabase } from './services/database';
+import { startAutomationEngine, stopAutomationEngine } from './services/automation-engine';
 import { loadCredentialsFromDisk } from './services/credentials';
 import { closeDanglingSession } from './services/streak-tracker';
 import { loadTokensFromDisk } from './services/twitch-auth';
@@ -82,6 +84,7 @@ function installProductionCsp(): void {
     "img-src 'self' data: https:",
     "font-src 'self'",
     "connect-src 'self' https://id.twitch.tv https://api.twitch.tv wss://eventsub.wss.twitch.tv wss://irc-ws.chat.twitch.tv",
+    "media-src 'self' file:",
     "base-uri 'none'",
     "form-action 'none'",
     "frame-ancestors 'none'",
@@ -115,6 +118,7 @@ app.whenReady().then(async () => {
   installProductionCsp();
 
   registerAuthHandlers();
+  registerAutomationHandlers();
   registerBotHandlers();
   registerCommandHandlers();
   registerTimerHandlers();
@@ -139,6 +143,8 @@ app.whenReady().then(async () => {
     console.warn('[auth] failed to restore session:', err);
   }
 
+  startAutomationEngine();
+
   createWindow();
 
   app.on('activate', () => {
@@ -156,5 +162,6 @@ app.on('will-quit', async () => {
   } catch {
     // ignore
   }
+  stopAutomationEngine();
   closeDatabase();
 });

--- a/electron/services/automation-engine.ts
+++ b/electron/services/automation-engine.ts
@@ -1,0 +1,584 @@
+import { app, BrowserWindow, dialog, type OpenDialogOptions } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { broadcast } from '../ipc/broadcast';
+import { interpolate } from '../lib/command-logic';
+import { awardExp } from './exp-engine';
+import { getDatabase } from './database';
+import { getSetting } from './settings-service';
+import { getCurrentTokens } from './twitch-auth';
+import { sendChat } from './twitch-chat';
+import { timeoutUser } from './twitch-helix';
+import { onBotEvent, type BotEventMap, type BotEventUser } from './bot-events';
+
+export type AutomationEventType =
+  | 'follow'
+  | 'subscription'
+  | 'sub_gift'
+  | 'cheer'
+  | 'raid'
+  | 'stream_online'
+  | 'stream_offline';
+
+type Operator =
+  | 'equals'
+  | 'not_equals'
+  | 'greater_than'
+  | 'less_than'
+  | 'contains'
+  | 'not_contains';
+
+export interface AutomationCondition {
+  field: string;
+  operator: Operator;
+  value: string | number;
+}
+
+export type AutomationAction =
+  | { type: 'send_chat_message'; message: string }
+  | { type: 'play_sound'; file: string }
+  | { type: 'send_discord_webhook'; webhook_key: string; message: string }
+  | { type: 'timeout_user'; duration: number; reason?: string }
+  | { type: 'add_exp'; amount: number }
+  | { type: 'delay'; seconds: number };
+
+export interface AutomationRow {
+  id: number;
+  name: string;
+  enabled: boolean;
+  event_type: AutomationEventType;
+  conditions: AutomationCondition[];
+  actions: AutomationAction[];
+  cooldown_seconds: number;
+  last_triggered_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface AutomationDbRow {
+  id: number;
+  name: string;
+  enabled: number;
+  event_type: string;
+  conditions: string;
+  actions: string;
+  cooldown_seconds: number;
+  last_triggered_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface AutomationInput {
+  name: string;
+  enabled?: boolean;
+  event_type: AutomationEventType;
+  conditions?: AutomationCondition[];
+  actions?: AutomationAction[];
+  cooldown_seconds?: number;
+}
+
+export interface AutomationUpdate extends Partial<AutomationInput> {
+  id: number;
+}
+
+export interface AutomationTestResult {
+  matched: boolean;
+  steps: Array<{ action: string; detail: string }>;
+  skippedReason?: string;
+}
+
+export interface SoundFile {
+  name: string;
+  url: string;
+}
+
+interface AutomationContext {
+  eventType: AutomationEventType;
+  event: Record<string, unknown>;
+  user: BotEventUser | null;
+  variables: Record<string, string | number>;
+}
+
+const EVENT_TYPES: AutomationEventType[] = [
+  'follow',
+  'subscription',
+  'sub_gift',
+  'cheer',
+  'raid',
+  'stream_online',
+  'stream_offline',
+];
+
+let automationsCache: AutomationRow[] = [];
+let subscriptions: Array<() => void> = [];
+
+export function startAutomationEngine(): void {
+  reloadAutomations();
+  if (subscriptions.length > 0) return;
+  for (const eventType of EVENT_TYPES) {
+    subscriptions.push(
+      onBotEvent(eventType, (event) => {
+        void handleEvent(eventType, event as BotEventMap[AutomationEventType]).catch(
+          (err) => console.error('[auto] event failed:', err),
+        );
+      }),
+    );
+  }
+}
+
+export function stopAutomationEngine(): void {
+  for (const unsubscribe of subscriptions) unsubscribe();
+  subscriptions = [];
+  automationsCache = [];
+}
+
+export function reloadAutomations(): void {
+  automationsCache = listAutomations().filter((automation) => automation.enabled);
+}
+
+export function listAutomations(): AutomationRow[] {
+  const rows = getDatabase()
+    .prepare('SELECT * FROM automations ORDER BY id DESC')
+    .all() as AutomationDbRow[];
+  return rows.map(rowToAutomation);
+}
+
+export function createAutomation(input: AutomationInput): AutomationRow {
+  const count = getDatabase()
+    .prepare('SELECT COUNT(*) AS count FROM automations')
+    .get() as { count: number };
+  if (count.count >= 20) throw new Error('Automations are limited to 20 total.');
+  const normalized = normalizeAutomation(input);
+  const info = getDatabase()
+    .prepare(
+      `INSERT INTO automations
+       (name, enabled, event_type, conditions, actions, cooldown_seconds)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      normalized.name,
+      normalized.enabled ? 1 : 0,
+      normalized.event_type,
+      JSON.stringify(normalized.conditions),
+      JSON.stringify(normalized.actions),
+      normalized.cooldown_seconds,
+    );
+  reloadAutomations();
+  return getAutomation(Number(info.lastInsertRowid));
+}
+
+export function updateAutomation(update: AutomationUpdate): AutomationRow {
+  const existing = getAutomation(update.id);
+  const normalized = normalizeAutomation({
+    name: update.name ?? existing.name,
+    enabled: update.enabled ?? existing.enabled,
+    event_type: update.event_type ?? existing.event_type,
+    conditions: update.conditions ?? existing.conditions,
+    actions: update.actions ?? existing.actions,
+    cooldown_seconds: update.cooldown_seconds ?? existing.cooldown_seconds,
+  });
+  getDatabase()
+    .prepare(
+      `UPDATE automations
+       SET name = ?, enabled = ?, event_type = ?, conditions = ?, actions = ?,
+           cooldown_seconds = ?, updated_at = unixepoch()
+       WHERE id = ?`,
+    )
+    .run(
+      normalized.name,
+      normalized.enabled ? 1 : 0,
+      normalized.event_type,
+      JSON.stringify(normalized.conditions),
+      JSON.stringify(normalized.actions),
+      normalized.cooldown_seconds,
+      update.id,
+    );
+  reloadAutomations();
+  return getAutomation(update.id);
+}
+
+export function deleteAutomation(id: number): void {
+  const info = getDatabase().prepare('DELETE FROM automations WHERE id = ?').run(id);
+  if (info.changes === 0) throw new Error(`Automation ${id} not found.`);
+  reloadAutomations();
+}
+
+export function toggleAutomation(id: number): AutomationRow {
+  const existing = getAutomation(id);
+  return updateAutomation({ id, enabled: !existing.enabled });
+}
+
+export function testAutomation(input: AutomationInput): AutomationTestResult {
+  const automation = normalizeAutomation(input);
+  const ctx = buildContext(automation.event_type, mockEvent(automation.event_type));
+  const matched = conditionsMatch(automation.conditions, ctx);
+  if (!matched) {
+    return { matched: false, steps: [], skippedReason: 'conditions_not_met' };
+  }
+  return {
+    matched: true,
+    steps: automation.actions.map((action) => previewAction(action, ctx)),
+  };
+}
+
+export async function listSounds(): Promise<SoundFile[]> {
+  const dir = soundsDir();
+  await fs.promises.mkdir(dir, { recursive: true });
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && isSupportedSound(entry.name))
+    .map((entry) => soundFile(entry.name));
+}
+
+export async function addSoundFromDialog(
+  window: BrowserWindow | null,
+): Promise<SoundFile[] | null> {
+  const options: OpenDialogOptions = {
+    title: 'Add sound',
+    properties: ['openFile', 'multiSelections'],
+    filters: [{ name: 'Audio', extensions: ['mp3', 'wav'] }],
+  };
+  const result = window
+    ? await dialog.showOpenDialog(window, options)
+    : await dialog.showOpenDialog(options);
+  if (result.canceled) return null;
+  const dir = soundsDir();
+  await fs.promises.mkdir(dir, { recursive: true });
+  for (const source of result.filePaths) {
+    const name = path.basename(source);
+    if (!isSupportedSound(name)) continue;
+    await fs.promises.copyFile(source, path.join(dir, name));
+  }
+  return listSounds();
+}
+
+export async function deleteSound(name: string): Promise<void> {
+  const safeName = path.basename(name);
+  if (!isSupportedSound(safeName)) throw new Error('Unsupported sound file.');
+  await fs.promises.rm(path.join(soundsDir(), safeName), { force: true });
+}
+
+export function getSoundsDirectory(): string {
+  return soundsDir();
+}
+
+async function handleEvent(
+  eventType: AutomationEventType,
+  event: BotEventMap[AutomationEventType],
+): Promise<void> {
+  const ctx = buildContext(eventType, event);
+  const matching = automationsCache.filter(
+    (automation) =>
+      automation.enabled &&
+      automation.event_type === eventType &&
+      conditionsMatch(automation.conditions, ctx) &&
+      cooldownReady(automation),
+  );
+
+  for (const automation of matching) {
+    await executeAutomation(automation, ctx);
+  }
+}
+
+async function executeAutomation(
+  automation: AutomationRow,
+  ctx: AutomationContext,
+): Promise<void> {
+  for (const action of automation.actions) {
+    try {
+      await executeAction(action, ctx);
+    } catch (err) {
+      console.error(`[auto] action ${action.type} failed:`, err);
+    }
+  }
+  const now = Math.floor(Date.now() / 1000);
+  getDatabase()
+    .prepare('UPDATE automations SET last_triggered_at = ?, updated_at = unixepoch() WHERE id = ?')
+    .run(now, automation.id);
+  automation.last_triggered_at = now;
+  broadcast('automations:triggered', { id: automation.id, timestamp: now });
+}
+
+async function executeAction(
+  action: AutomationAction,
+  ctx: AutomationContext,
+): Promise<void> {
+  switch (action.type) {
+    case 'send_chat_message':
+      await sendChat(resolveTemplate(action.message, ctx));
+      break;
+    case 'play_sound':
+      broadcast('sound:play', soundFile(action.file));
+      break;
+    case 'send_discord_webhook':
+      await sendDiscordWebhook(action.webhook_key, resolveTemplate(action.message, ctx));
+      break;
+    case 'timeout_user':
+      await timeoutTriggeringUser(ctx, action.duration, action.reason);
+      break;
+    case 'add_exp':
+      addExpToTriggeringUser(ctx, action.amount);
+      break;
+    case 'delay':
+      await sleep(Math.min(Math.max(action.seconds, 0), 30) * 1000);
+      break;
+  }
+}
+
+function conditionsMatch(
+  conditions: AutomationCondition[],
+  ctx: AutomationContext,
+): boolean {
+  return conditions.every((condition) => {
+    const actual = ctx.event[condition.field];
+    const expected = condition.value;
+    switch (condition.operator) {
+      case 'equals':
+        return String(actual) === String(expected);
+      case 'not_equals':
+        return String(actual) !== String(expected);
+      case 'greater_than':
+        return Number(actual) > Number(expected);
+      case 'less_than':
+        return Number(actual) < Number(expected);
+      case 'contains':
+        return String(actual ?? '').includes(String(expected));
+      case 'not_contains':
+        return !String(actual ?? '').includes(String(expected));
+      default:
+        return false;
+    }
+  });
+}
+
+function cooldownReady(automation: AutomationRow): boolean {
+  if (automation.cooldown_seconds <= 0 || !automation.last_triggered_at) return true;
+  return Math.floor(Date.now() / 1000) - automation.last_triggered_at >= automation.cooldown_seconds;
+}
+
+function buildContext(
+  eventType: AutomationEventType,
+  event: BotEventMap[AutomationEventType],
+): AutomationContext {
+  const data = normalizeEventData(eventType, event);
+  const user = getUserFromEvent(eventType, event);
+  const variables: Record<string, string | number> = {
+    user: String(user?.displayName ?? data.fromDisplayName ?? data.fromChannel ?? 'stream'),
+    event: eventType,
+    raid_viewers: Number(data.viewer_count ?? 0),
+    bits: Number(data.bits ?? 0),
+    tier: String(data.tier ?? ''),
+    total: Number(data.total ?? 0),
+  };
+  return { eventType, event: data, user, variables };
+}
+
+function normalizeEventData(
+  eventType: AutomationEventType,
+  event: BotEventMap[AutomationEventType],
+): Record<string, unknown> {
+  switch (eventType) {
+    case 'raid': {
+      const raid = event as BotEventMap['raid'];
+      return {
+        ...raid,
+        viewer_count: raid.viewers,
+      };
+    }
+    case 'cheer':
+      return event as Record<string, unknown>;
+    case 'subscription':
+      return event as Record<string, unknown>;
+    case 'sub_gift':
+      return event as Record<string, unknown>;
+    default:
+      return event as Record<string, unknown>;
+  }
+}
+
+function getUserFromEvent(
+  eventType: AutomationEventType,
+  event: BotEventMap[AutomationEventType],
+): BotEventUser | null {
+  if (eventType === 'raid' || eventType === 'stream_online' || eventType === 'stream_offline') {
+    return null;
+  }
+  const maybe = event as { user?: BotEventUser | null };
+  return maybe.user ?? null;
+}
+
+function resolveTemplate(template: string, ctx: AutomationContext): string {
+  return interpolate(template, ctx.variables);
+}
+
+async function sendDiscordWebhook(key: string, message: string): Promise<void> {
+  const normalized = normalizeWebhookKey(key);
+  const url = getSetting(`discord_webhook_${normalized}`, '');
+  if (!url) {
+    console.warn(`[auto] discord webhook ${normalized} is empty`);
+    return;
+  }
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: message }),
+  });
+  if (!res.ok) {
+    throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function timeoutTriggeringUser(
+  ctx: AutomationContext,
+  duration: number,
+  reason?: string,
+): Promise<void> {
+  const tokens = getCurrentTokens();
+  if (!tokens || !ctx.user) return;
+  await timeoutUser(
+    tokens.user.id,
+    tokens.user.id,
+    ctx.user.id,
+    Math.max(1, Math.floor(duration)),
+    reason ?? 'Automation',
+  );
+}
+
+function addExpToTriggeringUser(ctx: AutomationContext, amount: number): void {
+  if (!ctx.user) return;
+  awardExp(ctx.user.id, ctx.user.displayName, Math.floor(amount), 'admin', {
+    data: { automation: true, event: ctx.eventType },
+  });
+}
+
+function previewAction(
+  action: AutomationAction,
+  ctx: AutomationContext,
+): { action: string; detail: string } {
+  switch (action.type) {
+    case 'send_chat_message':
+      return { action: action.type, detail: resolveTemplate(action.message, ctx) };
+    case 'play_sound':
+      return { action: action.type, detail: action.file };
+    case 'send_discord_webhook':
+      return {
+        action: action.type,
+        detail: `${action.webhook_key}: ${resolveTemplate(action.message, ctx)}`,
+      };
+    case 'timeout_user':
+      return { action: action.type, detail: `${action.duration}s` };
+    case 'add_exp':
+      return { action: action.type, detail: `${action.amount} EXP` };
+    case 'delay':
+      return { action: action.type, detail: `${action.seconds}s` };
+  }
+}
+
+function getAutomation(id: number): AutomationRow {
+  const row = getDatabase()
+    .prepare('SELECT * FROM automations WHERE id = ?')
+    .get(id) as AutomationDbRow | undefined;
+  if (!row) throw new Error(`Automation ${id} not found.`);
+  return rowToAutomation(row);
+}
+
+function normalizeAutomation(input: AutomationInput): Omit<AutomationRow, 'id' | 'last_triggered_at' | 'created_at' | 'updated_at'> {
+  const name = input.name.trim();
+  if (!name) throw new Error('Automation name cannot be empty.');
+  if (!EVENT_TYPES.includes(input.event_type)) throw new Error('Invalid event type.');
+  const actions = input.actions ?? [];
+  const conditions = input.conditions ?? [];
+  if (actions.length > 10) throw new Error('Automations can have at most 10 actions.');
+  const cooldown = input.cooldown_seconds ?? 0;
+  if (!Number.isInteger(cooldown) || cooldown < 0) {
+    throw new Error('Cooldown must be a non-negative integer.');
+  }
+  validateJsonArray(conditions, 'conditions');
+  validateJsonArray(actions, 'actions');
+  return {
+    name,
+    enabled: input.enabled ?? true,
+    event_type: input.event_type,
+    conditions,
+    actions,
+    cooldown_seconds: cooldown,
+  };
+}
+
+function validateJsonArray(value: unknown, label: string): void {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`);
+}
+
+function rowToAutomation(row: AutomationDbRow): AutomationRow {
+  return {
+    id: row.id,
+    name: row.name,
+    enabled: row.enabled === 1,
+    event_type: row.event_type as AutomationEventType,
+    conditions: safeParseArray<AutomationCondition>(row.conditions),
+    actions: safeParseArray<AutomationAction>(row.actions),
+    cooldown_seconds: row.cooldown_seconds,
+    last_triggered_at: row.last_triggered_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function safeParseArray<T>(json: string): T[] {
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function mockEvent(eventType: AutomationEventType): BotEventMap[AutomationEventType] {
+  const user = { id: '1234', login: 'viewer', displayName: 'Viewer' };
+  switch (eventType) {
+    case 'follow':
+      return { user, timestamp: new Date().toISOString() };
+    case 'subscription':
+      return { user, tier: '1000', months: 3, isGift: false, timestamp: new Date().toISOString() };
+    case 'sub_gift':
+      return { user, total: 5, tier: '1000', isAnonymous: false, timestamp: new Date().toISOString() };
+    case 'cheer':
+      return { user, bits: 500, message: 'cheer!', timestamp: new Date().toISOString() };
+    case 'raid':
+      return {
+        fromChannel: 'raider',
+        fromDisplayName: 'Raider',
+        viewers: 42,
+        timestamp: new Date().toISOString(),
+      };
+    case 'stream_online':
+      return { timestamp: new Date().toISOString() };
+    case 'stream_offline':
+      return { timestamp: new Date().toISOString() };
+  }
+}
+
+function soundsDir(): string {
+  return path.join(app.getPath('userData'), 'sounds');
+}
+
+function isSupportedSound(name: string): boolean {
+  return /\.(mp3|wav)$/i.test(name);
+}
+
+function soundFile(name: string): SoundFile {
+  const safeName = path.basename(name);
+  return {
+    name: safeName,
+    url: pathToFileURL(path.join(soundsDir(), safeName)).toString(),
+  };
+}
+
+function normalizeWebhookKey(key: string): string {
+  return key.trim().toLowerCase().replace(/^discord_webhook_/, '').replace(/[^a-z0-9_-]/g, '_');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/electron/services/database.ts
+++ b/electron/services/database.ts
@@ -42,6 +42,9 @@ export const DEFAULT_SETTINGS: Record<string, string> = {
   mod_escalation_2_timeout: '10',
   mod_escalation_3_timeout: '600',
   mod_escalation_4_timeout: '86400',
+  discord_webhook_default: '',
+  discord_webhook_raids: '',
+  discord_webhook_follows: '',
 };
 
 let db: DB | null = null;

--- a/electron/services/settings-service.ts
+++ b/electron/services/settings-service.ts
@@ -37,3 +37,11 @@ export function updateSetting(key: string, value: unknown): void {
 
   broadcast('settings:updated', { key, value: stored });
 }
+
+export function deleteSetting(key: string): void {
+  if (!isKnownSettingKey(key)) {
+    throw new Error(`Unknown setting key: ${key}`);
+  }
+  getDatabase().prepare('DELETE FROM settings WHERE key = ?').run(key);
+  broadcast('settings:deleted', { key });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,9 @@ import { NavHotkeys } from './components/NavHotkeys';
 import { NoticeBanner } from './components/NoticeBanner';
 import { Sidebar } from './components/Sidebar';
 import { TopBar } from './components/TopBar';
+import { on } from './lib/ipc';
 import { Analytics } from './pages/Analytics';
+import { Automations } from './pages/Automations';
 import { Commands } from './pages/Commands';
 import { Dashboard } from './pages/Dashboard';
 import { Loyalty } from './pages/Loyalty';
@@ -16,6 +18,7 @@ import { Settings as SettingsPage } from './pages/Settings';
 import { SignIn } from './pages/SignIn';
 import { Timers } from './pages/Timers';
 import { useAppStore } from './stores/useAppStore';
+import type { SoundFile } from './lib/types';
 
 const PAGE_TITLES: Record<string, string> = {
   '/': 'Dashboard',
@@ -23,6 +26,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/timers': 'Timers',
   '/loyalty': 'Loyalty',
   '/moderation': 'Moderation',
+  '/automations': 'Automations',
   '/analytics': 'Analytics',
   '/settings': 'Settings',
 };
@@ -38,6 +42,13 @@ export default function App() {
   const location = useLocation();
 
   useEffect(() => init(), [init]);
+  useEffect(() => {
+    const off = on<SoundFile>('sound:play', (sound) => {
+      const audio = new Audio(sound.url);
+      void audio.play();
+    });
+    return off;
+  }, []);
 
   // Popout windows render a bare view — no sidebar, top bar or auth gate.
   if (location.pathname.startsWith('/popout/')) {
@@ -79,6 +90,7 @@ function InnerRoutes() {
           <Route path="/timers" element={<Timers />} />
           <Route path="/loyalty" element={<Loyalty />} />
           <Route path="/moderation" element={<Moderation />} />
+          <Route path="/automations" element={<Automations />} />
           <Route path="/analytics" element={<Analytics />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -62,6 +62,14 @@ export function ShieldIcon(props: IconProps) {
   );
 }
 
+export function ZapIcon(props: IconProps) {
+  return (
+    <svg {...baseProps} {...props}>
+      <polygon points="13 2 3 14 11 14 10 22 21 9 13 9" />
+    </svg>
+  );
+}
+
 export function BarChartIcon(props: IconProps) {
   return (
     <svg {...baseProps} {...props}>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ShieldIcon,
   TerminalIcon,
   TrophyIcon,
+  ZapIcon,
 } from './Icons';
 
 const NAV = [
@@ -16,6 +17,7 @@ const NAV = [
   { to: '/timers', label: 'Timers', icon: ClockIcon, end: false },
   { to: '/loyalty', label: 'Loyalty', icon: TrophyIcon, end: false },
   { to: '/moderation', label: 'Moderation', icon: ShieldIcon, end: false },
+  { to: '/automations', label: 'Automations', icon: ZapIcon, end: false },
   { to: '/analytics', label: 'Analytics', icon: BarChartIcon, end: false },
   { to: '/settings', label: 'Settings', icon: GearIcon, end: false },
 ] as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,6 +71,59 @@ export interface ModStatus {
   missingScopes: string[];
 }
 
+export type AutomationEventType =
+  | 'follow'
+  | 'subscription'
+  | 'sub_gift'
+  | 'cheer'
+  | 'raid'
+  | 'stream_online'
+  | 'stream_offline';
+
+export interface AutomationCondition {
+  field: string;
+  operator:
+    | 'equals'
+    | 'not_equals'
+    | 'greater_than'
+    | 'less_than'
+    | 'contains'
+    | 'not_contains';
+  value: string | number;
+}
+
+export type AutomationAction =
+  | { type: 'send_chat_message'; message: string }
+  | { type: 'play_sound'; file: string }
+  | { type: 'send_discord_webhook'; webhook_key: string; message: string }
+  | { type: 'timeout_user'; duration: number; reason?: string }
+  | { type: 'add_exp'; amount: number }
+  | { type: 'delay'; seconds: number };
+
+export interface Automation {
+  id: number;
+  name: string;
+  enabled: boolean;
+  event_type: AutomationEventType;
+  conditions: AutomationCondition[];
+  actions: AutomationAction[];
+  cooldown_seconds: number;
+  last_triggered_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface AutomationTestResult {
+  matched: boolean;
+  steps: Array<{ action: string; detail: string }>;
+  skippedReason?: string;
+}
+
+export interface SoundFile {
+  name: string;
+  url: string;
+}
+
 export interface UserRow {
   twitch_id: string;
   username: string;

--- a/src/pages/Automations.tsx
+++ b/src/pages/Automations.tsx
@@ -1,0 +1,702 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useConfirm } from '../components/ConfirmProvider';
+import { Modal } from '../components/Modal';
+import { PlusIcon, TrashIcon } from '../components/Icons';
+import { invoke, on, tryInvoke } from '../lib/ipc';
+import type {
+  Automation,
+  AutomationAction,
+  AutomationCondition,
+  AutomationEventType,
+  AutomationTestResult,
+} from '../lib/types';
+
+const EVENT_TYPES: AutomationEventType[] = [
+  'follow',
+  'subscription',
+  'sub_gift',
+  'cheer',
+  'raid',
+  'stream_online',
+  'stream_offline',
+];
+
+const OPERATORS: AutomationCondition['operator'][] = [
+  'equals',
+  'not_equals',
+  'greater_than',
+  'less_than',
+  'contains',
+  'not_contains',
+];
+
+const FIELD_BY_EVENT: Record<AutomationEventType, string[]> = {
+  follow: [],
+  subscription: ['tier', 'isGift'],
+  sub_gift: ['total', 'tier'],
+  cheer: ['bits'],
+  raid: ['viewer_count'],
+  stream_online: [],
+  stream_offline: [],
+};
+
+type EditorState = { mode: 'create' | 'edit'; automation?: Automation };
+
+export function Automations() {
+  const confirm = useConfirm();
+  const [automations, setAutomations] = useState<Automation[]>([]);
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const res = await tryInvoke<Automation[]>('automations:list');
+    if (res.success) setAutomations(res.data);
+    else setError(res.error);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const off = on('automations:triggered', () => {
+      void refresh();
+    });
+    return off;
+  }, [refresh]);
+
+  const toggle = async (automation: Automation) => {
+    await invoke('automations:toggle', automation.id);
+    await refresh();
+  };
+
+  const remove = async (automation: Automation) => {
+    const ok = await confirm({
+      title: 'Delete automation',
+      message: (
+        <>
+          Permanently delete <span className="font-mono text-text">{automation.name}</span>?
+        </>
+      ),
+      confirmLabel: 'Delete',
+      tone: 'danger',
+    });
+    if (!ok) return;
+    await invoke('automations:delete', automation.id);
+    await refresh();
+  };
+
+  const save = async (input: AutomationInputShape) => {
+    if (input.id) await invoke('automations:update', input);
+    else await invoke('automations:create', input);
+    setEditor(null);
+    await refresh();
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-text">
+            Automations
+          </h2>
+          <p className="text-xs text-text-dim">
+            Event-triggered actions with conditions, cooldowns, and previews.
+          </p>
+        </div>
+        <button
+          onClick={() => setEditor({ mode: 'create' })}
+          disabled={automations.length >= 20}
+          className="flex items-center gap-2 border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20 disabled:opacity-50"
+        >
+          <PlusIcon width={14} height={14} />
+          New Automation
+        </button>
+      </div>
+
+      {error && (
+        <div className="border border-offline/40 bg-offline/10 px-3 py-2 text-xs text-offline">
+          {error}
+        </div>
+      )}
+
+      <div className="grid gap-3">
+        {automations.map((automation) => (
+          <div
+            key={automation.id}
+            className="grid cursor-pointer grid-cols-[1fr_140px_120px_60px_40px] items-center gap-4 border border-border bg-bg-panel px-4 py-3 hover:bg-bg-hover"
+            onClick={() => setEditor({ mode: 'edit', automation })}
+          >
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-text">
+                {automation.name}
+              </div>
+              <div className="truncate text-xs text-text-dim">
+                {automation.conditions.length} conditions, {automation.actions.length} actions
+              </div>
+            </div>
+            <div className="font-mono text-xs text-text-muted">
+              {automation.event_type}
+            </div>
+            <div className="font-mono text-xs text-text-muted">
+              {automation.last_triggered_at
+                ? new Date(automation.last_triggered_at * 1000).toLocaleString()
+                : 'never'}
+            </div>
+            <div onClick={(e) => e.stopPropagation()}>
+              <Toggle
+                value={automation.enabled}
+                onChange={() => {
+                  void toggle(automation);
+                }}
+              />
+            </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                void remove(automation);
+              }}
+              className="text-text-dim hover:text-offline"
+              aria-label={`Delete ${automation.name}`}
+            >
+              <TrashIcon width={14} height={14} />
+            </button>
+          </div>
+        ))}
+        {automations.length === 0 && (
+          <div className="border border-border bg-bg-panel px-6 py-16 text-center text-sm text-text-dim">
+            No automations yet.
+          </div>
+        )}
+      </div>
+
+      {editor && (
+        <AutomationEditor
+          mode={editor.mode}
+          automation={editor.automation}
+          onClose={() => setEditor(null)}
+          onSave={save}
+        />
+      )}
+    </div>
+  );
+}
+
+interface AutomationInputShape {
+  id?: number;
+  name: string;
+  enabled: boolean;
+  event_type: AutomationEventType;
+  conditions: AutomationCondition[];
+  actions: AutomationAction[];
+  cooldown_seconds: number;
+}
+
+function AutomationEditor({
+  mode,
+  automation,
+  onClose,
+  onSave,
+}: {
+  mode: 'create' | 'edit';
+  automation?: Automation;
+  onClose: () => void;
+  onSave: (input: AutomationInputShape) => Promise<void>;
+}) {
+  const [name, setName] = useState(automation?.name ?? '');
+  const [eventType, setEventType] = useState<AutomationEventType>(
+    automation?.event_type ?? 'follow',
+  );
+  const [conditions, setConditions] = useState<AutomationCondition[]>(
+    automation?.conditions ?? [],
+  );
+  const [actions, setActions] = useState<AutomationAction[]>(
+    automation?.actions ?? [{ type: 'send_chat_message', message: 'Thanks {user}!' }],
+  );
+  const [cooldown, setCooldown] = useState(automation?.cooldown_seconds ?? 0);
+  const [enabled, setEnabled] = useState(automation?.enabled ?? true);
+  const [error, setError] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<AutomationTestResult | null>(null);
+
+  const fields = useMemo(() => FIELD_BY_EVENT[eventType], [eventType]);
+
+  const save = async () => {
+    setError(null);
+    try {
+      await onSave({
+        id: automation?.id,
+        name,
+        enabled,
+        event_type: eventType,
+        conditions,
+        actions,
+        cooldown_seconds: cooldown,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    }
+  };
+
+  const test = async () => {
+    setError(null);
+    try {
+      const result = await invoke<AutomationTestResult>('automations:test', {
+        name: name || 'Test automation',
+        enabled,
+        event_type: eventType,
+        conditions,
+        actions,
+        cooldown_seconds: cooldown,
+      });
+      setTestResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Test failed.');
+    }
+  };
+
+  return (
+    <Modal
+      title={mode === 'create' ? 'New Automation' : `Edit ${automation?.name}`}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            onClick={() => {
+              void test();
+            }}
+            className="border border-border bg-bg-panel px-3 py-1.5 text-xs uppercase tracking-wider text-text-muted hover:bg-bg-hover"
+          >
+            Test
+          </button>
+          <button
+            onClick={onClose}
+            className="border border-border bg-bg-panel px-3 py-1.5 text-xs uppercase tracking-wider text-text-muted hover:bg-bg-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => {
+              void save();
+            }}
+            disabled={!name.trim() || actions.length === 0}
+            className="border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20 disabled:opacity-50"
+          >
+            Save
+          </button>
+        </>
+      }
+    >
+      <div className="max-h-[70vh] space-y-5 overflow-y-auto pr-1">
+        {error && (
+          <div className="border border-offline/40 bg-offline/10 px-3 py-2 text-xs text-offline">
+            {error}
+          </div>
+        )}
+
+        <div className="grid grid-cols-[1fr_180px] gap-4">
+          <Field label="Name">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+            />
+          </Field>
+          <Field label="Event">
+            <select
+              value={eventType}
+              onChange={(e) => {
+                setEventType(e.target.value as AutomationEventType);
+                setConditions([]);
+              }}
+              className="w-full border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+            >
+              {EVENT_TYPES.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <SectionTitle title="Conditions" />
+        <div className="space-y-2">
+          {conditions.map((condition, index) => (
+            <div key={index} className="grid grid-cols-[1fr_140px_1fr_28px] gap-2">
+              <select
+                value={condition.field}
+                onChange={(e) => updateCondition(index, { field: e.target.value })}
+                className="border border-border bg-bg px-2 py-1.5 text-xs text-text"
+              >
+                {fields.map((field) => (
+                  <option key={field} value={field}>
+                    {field}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={condition.operator}
+                onChange={(e) =>
+                  updateCondition(index, {
+                    operator: e.target.value as AutomationCondition['operator'],
+                  })
+                }
+                className="border border-border bg-bg px-2 py-1.5 text-xs text-text"
+              >
+                {OPERATORS.map((operator) => (
+                  <option key={operator} value={operator}>
+                    {operator}
+                  </option>
+                ))}
+              </select>
+              <input
+                value={condition.value}
+                onChange={(e) => updateCondition(index, { value: e.target.value })}
+                className="border border-border bg-bg px-2 py-1.5 text-xs text-text"
+              />
+              <IconButton onClick={() => removeCondition(index)} label="Remove condition" />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => addCondition(fields[0])}
+            disabled={fields.length === 0}
+            className="border border-border bg-bg px-2 py-1.5 text-[10px] uppercase tracking-wider text-text-muted hover:bg-bg-hover disabled:opacity-50"
+          >
+            Add condition
+          </button>
+        </div>
+
+        <SectionTitle title="Actions" />
+        <div className="space-y-3">
+          {actions.map((action, index) => (
+            <ActionEditor
+              key={index}
+              action={action}
+              index={index}
+              onChange={(next) => updateAction(index, next)}
+              onRemove={() => removeAction(index)}
+              onMove={(direction) => moveAction(index, direction)}
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => addAction()}
+            disabled={actions.length >= 10}
+            className="border border-border bg-bg px-2 py-1.5 text-[10px] uppercase tracking-wider text-text-muted hover:bg-bg-hover disabled:opacity-50"
+          >
+            Add action
+          </button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="Cooldown seconds">
+            <input
+              type="number"
+              min={0}
+              value={cooldown}
+              onChange={(e) => setCooldown(Number(e.target.value))}
+              className="w-full border border-border bg-bg px-2.5 py-1.5 font-mono text-sm text-text outline-none focus:border-accent"
+            />
+          </Field>
+          <label className="flex items-end gap-2 pb-1 text-xs text-text-muted">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              className="h-3.5 w-3.5 accent-accent"
+            />
+            Enabled
+          </label>
+        </div>
+
+        {testResult && (
+          <div className="border border-border bg-bg px-3 py-2">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-text-dim">
+              {testResult.matched ? 'matched' : testResult.skippedReason}
+            </div>
+            {testResult.steps.map((step, index) => (
+              <div key={index} className="mt-1 text-xs text-text-muted">
+                <span className="font-mono text-text">{step.action}</span>: {step.detail}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+
+  function addCondition(field?: string) {
+    if (!field) return;
+    setConditions((prev) => [
+      ...prev,
+      { field, operator: 'equals', value: '' },
+    ]);
+  }
+
+  function updateCondition(index: number, patch: Partial<AutomationCondition>) {
+    setConditions((prev) =>
+      prev.map((condition, i) => (i === index ? { ...condition, ...patch } : condition)),
+    );
+  }
+
+  function removeCondition(index: number) {
+    setConditions((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function addAction() {
+    setActions((prev) => [...prev, { type: 'send_chat_message', message: '' }]);
+  }
+
+  function updateAction(index: number, next: AutomationAction) {
+    setActions((prev) => prev.map((action, i) => (i === index ? next : action)));
+  }
+
+  function removeAction(index: number) {
+    setActions((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function moveAction(index: number, direction: -1 | 1) {
+    setActions((prev) => {
+      const next = [...prev];
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      const [item] = next.splice(index, 1);
+      if (!item) return prev;
+      next.splice(target, 0, item);
+      return next;
+    });
+  }
+}
+
+function ActionEditor({
+  action,
+  index,
+  onChange,
+  onRemove,
+  onMove,
+}: {
+  action: AutomationAction;
+  index: number;
+  onChange: (action: AutomationAction) => void;
+  onRemove: () => void;
+  onMove: (direction: -1 | 1) => void;
+}) {
+  return (
+    <div className="border border-border bg-bg p-3">
+      <div className="mb-2 grid grid-cols-[1fr_28px_28px_28px] gap-2">
+        <select
+          value={action.type}
+          onChange={(e) => onChange(defaultAction(e.target.value))}
+          className="border border-border bg-bg-panel px-2 py-1.5 text-xs text-text"
+        >
+          <option value="send_chat_message">send_chat_message</option>
+          <option value="play_sound">play_sound</option>
+          <option value="send_discord_webhook">send_discord_webhook</option>
+          <option value="timeout_user">timeout_user</option>
+          <option value="add_exp">add_exp</option>
+          <option value="delay">delay</option>
+        </select>
+        <SmallButton label="Up" onClick={() => onMove(-1)}>
+          ^
+        </SmallButton>
+        <SmallButton label="Down" onClick={() => onMove(1)}>
+          v
+        </SmallButton>
+        <IconButton onClick={onRemove} label={`Remove action ${index + 1}`} />
+      </div>
+      {renderActionFields(action, onChange)}
+    </div>
+  );
+}
+
+function renderActionFields(
+  action: AutomationAction,
+  onChange: (action: AutomationAction) => void,
+) {
+  switch (action.type) {
+    case 'send_chat_message':
+      return (
+        <TextInput
+          value={action.message}
+          placeholder="Welcome {user}!"
+          onChange={(message) => onChange({ ...action, message })}
+        />
+      );
+    case 'play_sound':
+      return (
+        <TextInput
+          value={action.file}
+          placeholder="alert.mp3"
+          onChange={(file) => onChange({ ...action, file })}
+        />
+      );
+    case 'send_discord_webhook':
+      return (
+        <div className="grid grid-cols-[140px_1fr] gap-2">
+          <TextInput
+            value={action.webhook_key}
+            placeholder="default"
+            onChange={(webhook_key) => onChange({ ...action, webhook_key })}
+          />
+          <TextInput
+            value={action.message}
+            placeholder="{user} triggered an event"
+            onChange={(message) => onChange({ ...action, message })}
+          />
+        </div>
+      );
+    case 'timeout_user':
+      return (
+        <div className="grid grid-cols-[120px_1fr] gap-2">
+          <NumberInput
+            value={action.duration}
+            onChange={(duration) => onChange({ ...action, duration })}
+          />
+          <TextInput
+            value={action.reason ?? ''}
+            placeholder="Reason"
+            onChange={(reason) => onChange({ ...action, reason })}
+          />
+        </div>
+      );
+    case 'add_exp':
+      return (
+        <NumberInput
+          value={action.amount}
+          onChange={(amount) => onChange({ ...action, amount })}
+        />
+      );
+    case 'delay':
+      return (
+        <NumberInput
+          value={action.seconds}
+          max={30}
+          onChange={(seconds) => onChange({ ...action, seconds })}
+        />
+      );
+  }
+}
+
+function defaultAction(type: string): AutomationAction {
+  switch (type) {
+    case 'play_sound':
+      return { type, file: '' };
+    case 'send_discord_webhook':
+      return { type, webhook_key: 'default', message: '' };
+    case 'timeout_user':
+      return { type, duration: 60, reason: 'Automation' };
+    case 'add_exp':
+      return { type, amount: 100 };
+    case 'delay':
+      return { type, seconds: 5 };
+    default:
+      return { type: 'send_chat_message', message: '' };
+  }
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs text-text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function SectionTitle({ title }: { title: string }) {
+  return (
+    <div className="border-b border-border pb-1 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+      {title}
+    </div>
+  );
+}
+
+function TextInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <input
+      value={value}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full border border-border bg-bg-panel px-2 py-1.5 text-xs text-text outline-none focus:border-accent"
+    />
+  );
+}
+
+function NumberInput({
+  value,
+  onChange,
+  max,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+  max?: number;
+}) {
+  return (
+    <input
+      type="number"
+      min={0}
+      max={max}
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      className="w-full border border-border bg-bg-panel px-2 py-1.5 font-mono text-xs text-text outline-none focus:border-accent"
+    />
+  );
+}
+
+function Toggle({ value, onChange }: { value: boolean; onChange: () => void }) {
+  return (
+    <button
+      onClick={onChange}
+      className={`relative h-4 w-8 border transition-colors ${
+        value ? 'border-accent bg-accent/30' : 'border-border bg-bg'
+      }`}
+      aria-pressed={value}
+    >
+      <span
+        className={`absolute top-0.5 h-2.5 w-2.5 transition-all ${
+          value ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-dim'
+        }`}
+      />
+    </button>
+  );
+}
+
+function IconButton({ onClick, label }: { onClick: () => void; label: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-8 w-7 items-center justify-center border border-border text-text-dim hover:text-offline"
+      aria-label={label}
+    >
+      <TrashIcon width={13} height={13} />
+    </button>
+  );
+}
+
+function SmallButton({
+  children,
+  label,
+  onClick,
+}: {
+  children: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="h-8 border border-border font-mono text-xs text-text-dim hover:bg-bg-hover hover:text-text"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,6 +11,7 @@ import {
 import { useConfirm } from '../components/ConfirmProvider';
 import { CredentialsCard } from '../components/CredentialsCard';
 import { invoke, on, tryInvoke } from '../lib/ipc';
+import type { SoundFile } from '../lib/types';
 import { useAppStore } from '../stores/useAppStore';
 
 interface NumericField {
@@ -21,6 +22,11 @@ interface NumericField {
   min?: number;
   max?: number;
   step?: number;
+}
+
+interface DiscordWebhook {
+  key: string;
+  url: string;
 }
 
 const EXP_FIELDS: NumericField[] = [
@@ -53,12 +59,26 @@ export function Settings() {
   const [resetting, setResetting] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [userCount, setUserCount] = useState<number | null>(null);
+  const [webhooks, setWebhooks] = useState<DiscordWebhook[]>([]);
+  const [sounds, setSounds] = useState<SoundFile[]>([]);
+  const [soundsDir, setSoundsDir] = useState('');
+  const [newWebhookKey, setNewWebhookKey] = useState('');
+  const [newWebhookUrl, setNewWebhookUrl] = useState('');
 
   const load = useCallback(async () => {
     setLoading(true);
-    const res = await tryInvoke<Record<string, string>>('settings:get-all');
-    if (res.success) setSettings(res.data);
-    else setError(res.error);
+    const [settingsRes, webhooksRes, soundsRes] = await Promise.all([
+      tryInvoke<Record<string, string>>('settings:get-all'),
+      tryInvoke<DiscordWebhook[]>('discord-webhooks:list'),
+      tryInvoke<{ directory: string; files: SoundFile[] }>('sounds:list'),
+    ]);
+    if (settingsRes.success) setSettings(settingsRes.data);
+    else setError(settingsRes.error);
+    if (webhooksRes.success) setWebhooks(webhooksRes.data);
+    if (soundsRes.success) {
+      setSounds(soundsRes.data.files);
+      setSoundsDir(soundsRes.data.directory);
+    }
     setLoading(false);
   }, []);
 
@@ -160,6 +180,58 @@ export function Settings() {
       setExporting(false);
     }
   }, [showNotice]);
+
+  const saveWebhook = useCallback(
+    async (key: string, url: string) => {
+      setError(null);
+      try {
+        const rows = await invoke<DiscordWebhook[]>('discord-webhooks:save', {
+          key,
+          url,
+        });
+        setWebhooks(rows);
+        setNewWebhookKey('');
+        setNewWebhookUrl('');
+        showNotice('success', `Saved webhook ${key}`, 3000);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Webhook save failed.');
+      }
+    },
+    [showNotice],
+  );
+
+  const deleteWebhook = useCallback(async (key: string) => {
+    const rows = await invoke<DiscordWebhook[]>('discord-webhooks:delete', key);
+    setWebhooks(rows);
+  }, []);
+
+  const testWebhook = useCallback(
+    async (key: string, url?: string) => {
+      setError(null);
+      try {
+        await invoke('discord-webhooks:test', { key, url });
+        showNotice('success', `Webhook ${key} sent a test message`, 3000);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Webhook test failed.');
+      }
+    },
+    [showNotice],
+  );
+
+  const addSound = useCallback(async () => {
+    const result = await invoke<SoundFile[] | null>('sounds:add');
+    if (result) setSounds(result);
+  }, []);
+
+  const deleteSound = useCallback(async (name: string) => {
+    const result = await invoke<SoundFile[]>('sounds:delete', name);
+    setSounds(result);
+  }, []);
+
+  const previewSound = useCallback((sound: SoundFile) => {
+    const audio = new Audio(sound.url);
+    void audio.play();
+  }, []);
 
   const levelBase = Number(settings.level_base ?? '100');
   const levelExponent = Number(settings.level_exponent ?? '1.5');
@@ -382,6 +454,81 @@ export function Settings() {
         </Field>
       </Section>
 
+      <Section title="Discord webhooks">
+        <div className="space-y-2">
+          {webhooks.map((hook) => (
+            <WebhookRow
+              key={hook.key}
+              hook={hook}
+              onSave={saveWebhook}
+              onDelete={deleteWebhook}
+              onTest={testWebhook}
+            />
+          ))}
+          <div className="grid grid-cols-[160px_1fr_auto] gap-2">
+            <input
+              value={newWebhookKey}
+              onChange={(e) => setNewWebhookKey(e.target.value)}
+              placeholder="name"
+              className="border border-border bg-bg px-2.5 py-1.5 font-mono text-xs text-text outline-none focus:border-accent"
+            />
+            <input
+              value={newWebhookUrl}
+              onChange={(e) => setNewWebhookUrl(e.target.value)}
+              placeholder="https://discord.com/api/webhooks/..."
+              className="border border-border bg-bg px-2.5 py-1.5 text-xs text-text outline-none focus:border-accent"
+            />
+            <button
+              onClick={() => {
+                void saveWebhook(newWebhookKey, newWebhookUrl);
+              }}
+              className="border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Sounds" hint={soundsDir}>
+        <div className="space-y-2">
+          <button
+            onClick={() => {
+              void addSound();
+            }}
+            className="border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20"
+          >
+            Add sound
+          </button>
+          <div className="grid gap-1">
+            {sounds.map((sound) => (
+              <div
+                key={sound.name}
+                className="flex items-center justify-between border border-border bg-bg px-3 py-2"
+              >
+                <span className="font-mono text-xs text-text">{sound.name}</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => previewSound(sound)}
+                    className="text-[10px] uppercase tracking-wider text-text-muted hover:text-accent"
+                  >
+                    Play
+                  </button>
+                  <button
+                    onClick={() => {
+                      void deleteSound(sound.name);
+                    }}
+                    className="text-[10px] uppercase tracking-wider text-text-muted hover:text-offline"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+
       <Section title="Data">
         <div className="flex items-center justify-between gap-4">
           <div>
@@ -473,6 +620,57 @@ function Section({
       </div>
       <div className="space-y-4 p-5">{children}</div>
     </section>
+  );
+}
+
+function WebhookRow({
+  hook,
+  onSave,
+  onDelete,
+  onTest,
+}: {
+  hook: DiscordWebhook;
+  onSave: (key: string, url: string) => Promise<void>;
+  onDelete: (key: string) => Promise<void>;
+  onTest: (key: string, url?: string) => Promise<void>;
+}) {
+  const [url, setUrl] = useState(hook.url);
+  useEffect(() => setUrl(hook.url), [hook.url]);
+  return (
+    <div className="grid grid-cols-[160px_1fr_auto_auto_auto] gap-2">
+      <div className="border border-border bg-bg px-2.5 py-1.5 font-mono text-xs text-text">
+        {hook.key}
+      </div>
+      <input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        className="border border-border bg-bg px-2.5 py-1.5 text-xs text-text outline-none focus:border-accent"
+      />
+      <button
+        onClick={() => {
+          void onTest(hook.key, url);
+        }}
+        className="border border-border bg-bg px-2.5 py-1.5 text-[10px] uppercase tracking-wider text-text-muted hover:bg-bg-hover"
+      >
+        Test
+      </button>
+      <button
+        onClick={() => {
+          void onSave(hook.key, url);
+        }}
+        className="border border-accent/50 bg-accent/10 px-2.5 py-1.5 text-[10px] uppercase tracking-wider text-accent hover:bg-accent/20"
+      >
+        Save
+      </button>
+      <button
+        onClick={() => {
+          void onDelete(hook.key);
+        }}
+        className="border border-offline/40 bg-offline/10 px-2.5 py-1.5 text-[10px] uppercase tracking-wider text-offline hover:bg-offline/20"
+      >
+        Delete
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #14\n\n## Summary\n- add automation persistence, CRUD IPC, dry-run previews, and an event-driven AutomationEngine\n- execute condition-gated action chains for follows, subs, gift subs, cheers, raids, and stream state events\n- support chat messages, sounds, Discord webhooks, user timeouts, bonus EXP, and bounded delays\n- add Automations route/sidebar UI with dynamic conditions/actions and test previews\n- add Discord webhook and sound-file management to Settings\n- update README for Timers, Moderation, and Automations\n\n## Validation\n- npm run typecheck\n- npm test\n- npm run lint\n- npm run build\n\n## Manual testing\nManual app testing is recommended before merge for sound playback, Discord webhooks, and Twitch-side timeout actions.