### PR TITLE
feat(webhooks): Discord embed builder + dedicated Webhooks page

### DIFF
--- a/electron/ipc/automations.ts
+++ b/electron/ipc/automations.ts
@@ -13,7 +13,12 @@ import {
   type AutomationInput,
   type AutomationUpdate,
 } from '../services/automation-engine';
-import { deleteSetting, getAllSettings, updateSetting } from '../services/settings-service';
+import {
+  deleteWebhook,
+  getWebhookUrl,
+  listWebhooks,
+  saveWebhook,
+} from '../services/discord-webhooks';
 
 type IpcResult<T> = { success: true; data: T } | { success: false; error: string };
 
@@ -75,7 +80,7 @@ export function registerAutomationHandlers(): void {
 
   ipcMain.handle('discord-webhooks:list', () => {
     try {
-      return ok(listDiscordWebhooks());
+      return ok(listWebhooks());
     } catch (err) {
       return fail(err);
     }
@@ -85,9 +90,8 @@ export function registerAutomationHandlers(): void {
     'discord-webhooks:save',
     (_event, payload: { key: string; url: string }) => {
       try {
-        const key = normalizeWebhookKey(payload.key);
-        updateSetting(`discord_webhook_${key}`, payload.url);
-        return ok(listDiscordWebhooks());
+        saveWebhook(payload.key, payload.url);
+        return ok(listWebhooks());
       } catch (err) {
         return fail(err);
       }
@@ -96,8 +100,8 @@ export function registerAutomationHandlers(): void {
 
   ipcMain.handle('discord-webhooks:delete', (_event, key: string) => {
     try {
-      deleteSetting(`discord_webhook_${normalizeWebhookKey(key)}`);
-      return ok(listDiscordWebhooks());
+      deleteWebhook(key);
+      return ok(listWebhooks());
     } catch (err) {
       return fail(err);
     }
@@ -107,9 +111,7 @@ export function registerAutomationHandlers(): void {
     'discord-webhooks:test',
     async (_event, payload: { key: string; url?: string }) => {
       try {
-        const url =
-          payload.url ??
-          getAllSettings()[`discord_webhook_${normalizeWebhookKey(payload.key)}`];
+        const url = payload.url ?? getWebhookUrl(payload.key);
         if (!url) throw new Error('Webhook URL is empty.');
         const res = await fetch(url, {
           method: 'POST',
@@ -156,22 +158,3 @@ export function registerAutomationHandlers(): void {
   });
 }
 
-function listDiscordWebhooks(): Array<{ key: string; url: string }> {
-  return Object.entries(getAllSettings())
-    .filter(([key]) => key.startsWith('discord_webhook_'))
-    .map(([key, url]) => ({
-      key: key.replace(/^discord_webhook_/, ''),
-      url,
-    }))
-    .sort((a, b) => a.key.localeCompare(b.key));
-}
-
-function normalizeWebhookKey(key: string): string {
-  const normalized = key
-    .trim()
-    .toLowerCase()
-    .replace(/^discord_webhook_/, '')
-    .replace(/[^a-z0-9_-]/g, '_');
-  if (!normalized) throw new Error('Webhook name is required.');
-  return normalized;
-}

--- a/electron/ipc/webhooks.ts
+++ b/electron/ipc/webhooks.ts
@@ -1,0 +1,59 @@
+import { ipcMain } from 'electron';
+import {
+  deleteEmbedTemplate,
+  listEmbedTemplates,
+  saveEmbedTemplate,
+  testEmbed,
+  type DiscordEmbed,
+} from '../services/discord-webhooks';
+
+type IpcResult<T> = { success: true; data: T } | { success: false; error: string };
+
+const ok = <T>(data: T): IpcResult<T> => ({ success: true, data });
+const fail = (err: unknown): IpcResult<never> => ({
+  success: false,
+  error: err instanceof Error ? err.message : String(err),
+});
+
+export function registerWebhookHandlers(): void {
+  ipcMain.handle('webhooks:getTemplates', () => {
+    try {
+      return ok(listEmbedTemplates());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle(
+    'webhooks:saveTemplate',
+    (_event, payload: { name: string; embed: DiscordEmbed }) => {
+      try {
+        saveEmbedTemplate(payload.name, payload.embed);
+        return ok(listEmbedTemplates());
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  ipcMain.handle('webhooks:deleteTemplate', (_event, name: string) => {
+    try {
+      deleteEmbedTemplate(name);
+      return ok(listEmbedTemplates());
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle(
+    'webhooks:testEmbed',
+    async (_event, payload: { webhook_key: string; embed: DiscordEmbed }) => {
+      try {
+        await testEmbed(payload.webhook_key, payload.embed);
+        return ok(null);
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ import { registerSessionHandlers } from './ipc/sessions';
 import { registerSettingsHandlers } from './ipc/settings';
 import { registerTimerHandlers } from './ipc/timers';
 import { registerUserHandlers } from './ipc/users';
+import { registerWebhookHandlers } from './ipc/webhooks';
 import { registerWindowHandlers } from './ipc/window';
 import { closeDatabase, initDatabase } from './services/database';
 import { startAutomationEngine, stopAutomationEngine } from './services/automation-engine';
@@ -127,6 +128,7 @@ app.whenReady().then(async () => {
   registerUserHandlers();
   registerAnalyticsHandlers();
   registerSettingsHandlers();
+  registerWebhookHandlers();
   registerWindowHandlers();
   registerDbHandlers();
   registerDiagnosticsHandlers();

--- a/electron/services/automation-engine.ts
+++ b/electron/services/automation-engine.ts
@@ -6,7 +6,7 @@ import { broadcast } from '../ipc/broadcast';
 import { interpolate } from '../lib/command-logic';
 import { awardExp } from './exp-engine';
 import { getDatabase } from './database';
-import { getSetting } from './settings-service';
+import { sendWebhook, type DiscordEmbed } from './discord-webhooks';
 import { getCurrentTokens } from './twitch-auth';
 import { sendChat } from './twitch-chat';
 import { timeoutUser } from './twitch-helix';
@@ -38,7 +38,12 @@ export interface AutomationCondition {
 export type AutomationAction =
   | { type: 'send_chat_message'; message: string }
   | { type: 'play_sound'; file: string }
-  | { type: 'send_discord_webhook'; webhook_key: string; message: string }
+  | {
+      type: 'send_discord_webhook';
+      webhook_key: string;
+      message?: string;
+      embed?: DiscordEmbed;
+    }
   | { type: 'timeout_user'; duration: number; reason?: string }
   | { type: 'add_exp'; amount: number }
   | { type: 'delay'; seconds: number };
@@ -312,7 +317,11 @@ async function executeAction(
       broadcast('sound:play', soundFile(action.file));
       break;
     case 'send_discord_webhook':
-      await sendDiscordWebhook(action.webhook_key, resolveTemplate(action.message, ctx));
+      await sendWebhook(
+        action.webhook_key,
+        { content: action.message, embed: action.embed },
+        ctx.variables,
+      );
       break;
     case 'timeout_user':
       await timeoutTriggeringUser(ctx, action.duration, action.reason);
@@ -412,23 +421,6 @@ function resolveTemplate(template: string, ctx: AutomationContext): string {
   return interpolate(template, ctx.variables);
 }
 
-async function sendDiscordWebhook(key: string, message: string): Promise<void> {
-  const normalized = normalizeWebhookKey(key);
-  const url = getSetting(`discord_webhook_${normalized}`, '');
-  if (!url) {
-    console.warn(`[auto] discord webhook ${normalized} is empty`);
-    return;
-  }
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content: message }),
-  });
-  if (!res.ok) {
-    throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
-  }
-}
-
 async function timeoutTriggeringUser(
   ctx: AutomationContext,
   duration: number,
@@ -461,11 +453,15 @@ function previewAction(
       return { action: action.type, detail: resolveTemplate(action.message, ctx) };
     case 'play_sound':
       return { action: action.type, detail: action.file };
-    case 'send_discord_webhook':
+    case 'send_discord_webhook': {
+      const parts: string[] = [];
+      if (action.message) parts.push(resolveTemplate(action.message, ctx));
+      if (action.embed) parts.push('[embed]');
       return {
         action: action.type,
-        detail: `${action.webhook_key}: ${resolveTemplate(action.message, ctx)}`,
+        detail: `${action.webhook_key}: ${parts.join(' ') || '(empty)'}`,
       };
+    }
     case 'timeout_user':
       return { action: action.type, detail: `${action.duration}s` };
     case 'add_exp':
@@ -573,10 +569,6 @@ function soundFile(name: string): SoundFile {
     name: safeName,
     url: pathToFileURL(path.join(soundsDir(), safeName)).toString(),
   };
-}
-
-function normalizeWebhookKey(key: string): string {
-  return key.trim().toLowerCase().replace(/^discord_webhook_/, '').replace(/[^a-z0-9_-]/g, '_');
 }
 
 function sleep(ms: number): Promise<void> {

--- a/electron/services/automation-engine.ts
+++ b/electron/services/automation-engine.ts
@@ -372,15 +372,51 @@ function buildContext(
 ): AutomationContext {
   const data = normalizeEventData(eventType, event);
   const user = getUserFromEvent(eventType, event);
+  const tier = String(data.tier ?? '');
+  const raidSize = Number(data.viewer_count ?? data.viewers ?? 0);
   const variables: Record<string, string | number> = {
     user: String(user?.displayName ?? data.fromDisplayName ?? data.fromChannel ?? 'stream'),
     event: eventType,
-    raid_viewers: Number(data.viewer_count ?? 0),
-    bits: Number(data.bits ?? 0),
-    tier: String(data.tier ?? ''),
+
+    // Raid
+    raider: String(data.fromDisplayName ?? data.fromChannel ?? ''),
+    raid_size: raidSize,
+    raid_viewers: raidSize, // legacy alias — keep before renaming in templates
+    from_channel: String(data.fromChannel ?? ''),
+
+    // Subscription / gift
+    tier,
+    tier_label: formatTierLabel(tier),
+    months: Number(data.months ?? 0),
+    is_gift: data.isGift ? 'yes' : 'no',
+    is_anonymous: data.isAnonymous ? 'yes' : 'no',
     total: Number(data.total ?? 0),
+    sub_message: String(data.message ?? ''),
+
+    // Cheer
+    bits: Number(data.bits ?? 0),
+    cheer_message: String(data.message ?? ''),
+
+    // Generic
+    timestamp: String(data.timestamp ?? new Date().toISOString()),
   };
   return { eventType, event: data, user, variables };
+}
+
+function formatTierLabel(tier: string): string {
+  switch (tier) {
+    case '1000':
+      return 'Tier 1';
+    case '2000':
+      return 'Tier 2';
+    case '3000':
+      return 'Tier 3';
+    case 'prime':
+    case 'Prime':
+      return 'Prime';
+    default:
+      return tier;
+  }
 }
 
 function normalizeEventData(

--- a/electron/services/discord-webhooks.ts
+++ b/electron/services/discord-webhooks.ts
@@ -1,0 +1,274 @@
+/**
+ * Discord webhook service: URL storage, embed templates, and the payload
+ * builder that resolves template variables across every embed string field.
+ */
+
+import { interpolate } from '../lib/command-logic';
+import { deleteSetting, getAllSettings, getSetting, updateSetting } from './settings-service';
+
+export interface DiscordEmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+export interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  author?: { name: string; icon_url?: string };
+  thumbnail?: { url: string };
+  fields?: DiscordEmbedField[];
+  footer?: { text: string };
+  timestamp?: boolean;
+}
+
+export interface EmbedTemplate {
+  name: string;
+  embed: DiscordEmbed;
+}
+
+export interface SendOptions {
+  content?: string;
+  embed?: DiscordEmbed;
+}
+
+export type TemplateVars = Record<string, string | number>;
+
+const WEBHOOK_PREFIX = 'discord_webhook_';
+const TEMPLATE_PREFIX = 'discord_embed_template_';
+
+export function normalizeWebhookKey(key: string): string {
+  const normalized = key
+    .trim()
+    .toLowerCase()
+    .replace(new RegExp(`^${WEBHOOK_PREFIX}`), '')
+    .replace(/[^a-z0-9_-]/g, '_');
+  if (!normalized) throw new Error('Webhook name is required.');
+  return normalized;
+}
+
+export function normalizeTemplateName(name: string): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(new RegExp(`^${TEMPLATE_PREFIX}`), '')
+    .replace(/[^a-z0-9_-]/g, '_');
+  if (!normalized) throw new Error('Template name is required.');
+  return normalized;
+}
+
+// ── webhook URL CRUD ──
+
+export function listWebhooks(): Array<{ key: string; url: string }> {
+  return Object.entries(getAllSettings())
+    .filter(([key]) => key.startsWith(WEBHOOK_PREFIX))
+    .map(([key, url]) => ({
+      key: key.slice(WEBHOOK_PREFIX.length),
+      url,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function saveWebhook(key: string, url: string): void {
+  const normalized = normalizeWebhookKey(key);
+  updateSetting(`${WEBHOOK_PREFIX}${normalized}`, url);
+}
+
+export function deleteWebhook(key: string): void {
+  const normalized = normalizeWebhookKey(key);
+  deleteSetting(`${WEBHOOK_PREFIX}${normalized}`);
+}
+
+export function getWebhookUrl(key: string): string {
+  const normalized = normalizeWebhookKey(key);
+  return getSetting(`${WEBHOOK_PREFIX}${normalized}`, '') ?? '';
+}
+
+// ── embed template CRUD ──
+
+export function listEmbedTemplates(): EmbedTemplate[] {
+  return Object.entries(getAllSettings())
+    .filter(([key]) => key.startsWith(TEMPLATE_PREFIX))
+    .map(([key, value]) => ({
+      name: key.slice(TEMPLATE_PREFIX.length),
+      embed: parseEmbed(value),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function saveEmbedTemplate(name: string, embed: DiscordEmbed): EmbedTemplate {
+  const normalized = normalizeTemplateName(name);
+  const sanitized = sanitizeEmbed(embed);
+  updateSetting(`${TEMPLATE_PREFIX}${normalized}`, JSON.stringify(sanitized));
+  return { name: normalized, embed: sanitized };
+}
+
+export function deleteEmbedTemplate(name: string): void {
+  const normalized = normalizeTemplateName(name);
+  deleteSetting(`${TEMPLATE_PREFIX}${normalized}`);
+}
+
+// ── send ──
+
+export async function sendWebhook(
+  key: string,
+  options: SendOptions,
+  vars: TemplateVars = {},
+): Promise<void> {
+  const url = getWebhookUrl(key);
+  if (!url) {
+    console.warn(`[discord] webhook ${key} is empty`);
+    return;
+  }
+  await postToUrl(url, options, vars);
+}
+
+export async function testEmbed(
+  webhookKey: string,
+  embed: DiscordEmbed,
+  vars: TemplateVars = MOCK_VARS,
+): Promise<void> {
+  const url = getWebhookUrl(webhookKey);
+  if (!url) throw new Error('Webhook URL is empty.');
+  await postToUrl(url, { embed }, vars);
+}
+
+export function buildPayload(
+  options: SendOptions,
+  vars: TemplateVars,
+): { content?: string; embeds?: object[] } {
+  const payload: { content?: string; embeds?: object[] } = {};
+  if (options.content?.trim()) {
+    payload.content = interpolate(options.content, vars);
+  }
+  if (options.embed) {
+    const built = buildEmbed(options.embed, vars);
+    if (built) payload.embeds = [built];
+  }
+  return payload;
+}
+
+const MOCK_VARS: TemplateVars = {
+  user: 'TestUser',
+  event: 'test',
+  level: 5,
+  raid_viewers: 42,
+  bits: 500,
+  tier: '1000',
+  total: 5,
+};
+
+async function postToUrl(
+  url: string,
+  options: SendOptions,
+  vars: TemplateVars,
+): Promise<void> {
+  const payload = buildPayload(options, vars);
+  if (!payload.content && !payload.embeds) {
+    throw new Error('Webhook payload is empty.');
+  }
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+function buildEmbed(embed: DiscordEmbed, vars: TemplateVars): object | null {
+  const out: Record<string, unknown> = {};
+  const title = resolveString(embed.title, vars);
+  if (title) out.title = title;
+  const description = resolveString(embed.description, vars);
+  if (description) out.description = description;
+  if (typeof embed.color === 'number' && Number.isFinite(embed.color)) {
+    out.color = clampColor(embed.color);
+  }
+  if (embed.author?.name) {
+    const author: Record<string, string> = {
+      name: interpolate(embed.author.name, vars),
+    };
+    const iconUrl = resolveString(embed.author.icon_url, vars);
+    if (iconUrl) author.icon_url = iconUrl;
+    out.author = author;
+  }
+  const thumbnailUrl = resolveString(embed.thumbnail?.url, vars);
+  if (thumbnailUrl) out.thumbnail = { url: thumbnailUrl };
+  if (embed.fields?.length) {
+    const fields = embed.fields
+      .map((field) => ({
+        name: interpolate(field.name ?? '', vars),
+        value: interpolate(field.value ?? '', vars),
+        inline: Boolean(field.inline),
+      }))
+      .filter((field) => field.name && field.value);
+    if (fields.length) out.fields = fields;
+  }
+  if (embed.footer?.text) {
+    out.footer = { text: interpolate(embed.footer.text, vars) };
+  }
+  if (embed.timestamp) {
+    out.timestamp = new Date().toISOString();
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function resolveString(
+  value: string | undefined,
+  vars: TemplateVars,
+): string | undefined {
+  if (!value) return undefined;
+  const resolved = interpolate(value, vars).trim();
+  return resolved ? resolved : undefined;
+}
+
+function clampColor(color: number): number {
+  return Math.max(0, Math.min(0xffffff, Math.floor(color)));
+}
+
+function parseEmbed(raw: string): DiscordEmbed {
+  try {
+    const parsed = JSON.parse(raw) as DiscordEmbed;
+    return sanitizeEmbed(parsed);
+  } catch {
+    return {};
+  }
+}
+
+function sanitizeEmbed(embed: DiscordEmbed): DiscordEmbed {
+  const out: DiscordEmbed = {};
+  if (typeof embed.title === 'string') out.title = embed.title;
+  if (typeof embed.description === 'string') out.description = embed.description;
+  if (typeof embed.color === 'number' && Number.isFinite(embed.color)) {
+    out.color = clampColor(embed.color);
+  }
+  if (embed.author && typeof embed.author.name === 'string') {
+    out.author = { name: embed.author.name };
+    if (typeof embed.author.icon_url === 'string') {
+      out.author.icon_url = embed.author.icon_url;
+    }
+  }
+  if (embed.thumbnail && typeof embed.thumbnail.url === 'string') {
+    out.thumbnail = { url: embed.thumbnail.url };
+  }
+  if (Array.isArray(embed.fields)) {
+    out.fields = embed.fields
+      .filter(
+        (field): field is DiscordEmbedField =>
+          !!field && typeof field.name === 'string' && typeof field.value === 'string',
+      )
+      .map((field) => ({
+        name: field.name,
+        value: field.value,
+        inline: Boolean(field.inline),
+      }));
+  }
+  if (embed.footer && typeof embed.footer.text === 'string') {
+    out.footer = { text: embed.footer.text };
+  }
+  if (embed.timestamp) out.timestamp = true;
+  return out;
+}

--- a/electron/services/discord-webhooks.ts
+++ b/electron/services/discord-webhooks.ts
@@ -151,12 +151,21 @@ export function buildPayload(
 
 const MOCK_VARS: TemplateVars = {
   user: 'TestUser',
-  event: 'test',
-  level: 5,
+  event: 'raid',
+  raider: 'TestUser',
+  raid_size: 42,
   raid_viewers: 42,
-  bits: 500,
+  from_channel: 'testuser',
   tier: '1000',
+  tier_label: 'Tier 1',
+  months: 6,
+  is_gift: 'no',
+  is_anonymous: 'no',
   total: 5,
+  sub_message: 'thanks for the stream!',
+  bits: 500,
+  cheer_message: 'cheer500 amazing!',
+  timestamp: new Date().toISOString(),
 };
 
 async function postToUrl(

--- a/electron/services/settings-service.ts
+++ b/electron/services/settings-service.ts
@@ -19,7 +19,7 @@ export function getSetting(key: string, fallback?: string): string | undefined {
 }
 
 const KNOWN_KEYS = new Set(Object.keys(DEFAULT_SETTINGS));
-const KNOWN_PREFIXES = ['mod_', 'discord_webhook_'] as const;
+const KNOWN_PREFIXES = ['mod_', 'discord_webhook_', 'discord_embed_template_'] as const;
 
 function isKnownSettingKey(key: string): boolean {
   return KNOWN_KEYS.has(key) || KNOWN_PREFIXES.some((prefix) => key.startsWith(prefix));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { Popout } from './pages/Popout';
 import { Settings as SettingsPage } from './pages/Settings';
 import { SignIn } from './pages/SignIn';
 import { Timers } from './pages/Timers';
+import { Webhooks } from './pages/Webhooks';
 import { useAppStore } from './stores/useAppStore';
 import type { SoundFile } from './lib/types';
 
@@ -27,6 +28,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/loyalty': 'Loyalty',
   '/moderation': 'Moderation',
   '/automations': 'Automations',
+  '/webhooks': 'Webhooks',
   '/analytics': 'Analytics',
   '/settings': 'Settings',
 };
@@ -91,6 +93,7 @@ function InnerRoutes() {
           <Route path="/loyalty" element={<Loyalty />} />
           <Route path="/moderation" element={<Moderation />} />
           <Route path="/automations" element={<Automations />} />
+          <Route path="/webhooks" element={<Webhooks />} />
           <Route path="/analytics" element={<Analytics />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -155,3 +155,13 @@ export function EyeOffIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function WebhookIcon(props: IconProps) {
+  return (
+    <svg {...baseProps} {...props}>
+      <path d="M18 16.98h-5.99c-1.66 0-3.01-1.34-3.01-3s1.34-3 3-3v0" />
+      <path d="M7.5 8.5a4.5 4.5 0 1 1 8.18 2.62" />
+      <path d="M9 14a4.5 4.5 0 1 0 6.5 4" />
+    </svg>
+  );
+}

--- a/src/components/NavHotkeys.tsx
+++ b/src/components/NavHotkeys.tsx
@@ -9,20 +9,15 @@ const ROUTES = [
   '/loyalty',
   '/moderation',
   '/automations',
+  '/webhooks',
   '/analytics',
   '/settings',
 ];
 
-// Dedicated nested-view hotkeys: pages with internal tabs map an extra slot.
-const NESTED_ROUTES: Record<string, string> = {
-  '9': '/moderation?tab=logs',
-};
-
 /**
- * Dev-only keyboard shortcuts: Alt+1..8 jump between the eight top-level
- * pages (sidebar order). Alt+9 deep-links to the Moderation Logs tab.
- * Useful for scripted screenshot runs and quick navigation without
- * reaching for the sidebar.
+ * Dev-only keyboard shortcuts: Alt+1..9 jump between the nine top-level
+ * pages (sidebar order). Useful for scripted screenshot runs and quick
+ * navigation without reaching for the sidebar.
  */
 export function NavHotkeys() {
   const navigate = useNavigate();
@@ -30,12 +25,6 @@ export function NavHotkeys() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
-      const nested = NESTED_ROUTES[e.key];
-      if (nested) {
-        e.preventDefault();
-        navigate(nested);
-        return;
-      }
       const idx = Number.parseInt(e.key, 10) - 1;
       if (Number.isNaN(idx) || idx < 0 || idx >= ROUTES.length) return;
       e.preventDefault();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ShieldIcon,
   TerminalIcon,
   TrophyIcon,
+  WebhookIcon,
   ZapIcon,
 } from './Icons';
 
@@ -18,6 +19,7 @@ const NAV = [
   { to: '/loyalty', label: 'Loyalty', icon: TrophyIcon, end: false },
   { to: '/moderation', label: 'Moderation', icon: ShieldIcon, end: false },
   { to: '/automations', label: 'Automations', icon: ZapIcon, end: false },
+  { to: '/webhooks', label: 'Webhooks', icon: WebhookIcon, end: false },
   { to: '/analytics', label: 'Analytics', icon: BarChartIcon, end: false },
   { to: '/settings', label: 'Settings', icon: GearIcon, end: false },
 ] as const;

--- a/src/lib/interpolate.ts
+++ b/src/lib/interpolate.ts
@@ -1,0 +1,12 @@
+/**
+ * Mirror of electron/lib/command-logic.ts → interpolate. Kept renderer-local
+ * because importing across the electron/src boundary would pull node-only deps.
+ */
+export function interpolate(
+  template: string,
+  vars: Record<string, string | number>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? String(vars[key]) : `{${key}}`,
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,10 +92,37 @@ export interface AutomationCondition {
   value: string | number;
 }
 
+export interface DiscordEmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+export interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  author?: { name: string; icon_url?: string };
+  thumbnail?: { url: string };
+  fields?: DiscordEmbedField[];
+  footer?: { text: string };
+  timestamp?: boolean;
+}
+
+export interface EmbedTemplate {
+  name: string;
+  embed: DiscordEmbed;
+}
+
 export type AutomationAction =
   | { type: 'send_chat_message'; message: string }
   | { type: 'play_sound'; file: string }
-  | { type: 'send_discord_webhook'; webhook_key: string; message: string }
+  | {
+      type: 'send_discord_webhook';
+      webhook_key: string;
+      message?: string;
+      embed?: DiscordEmbed;
+    }
   | { type: 'timeout_user'; duration: number; reason?: string }
   | { type: 'add_exp'; amount: number }
   | { type: 'delay'; seconds: number };

--- a/src/pages/Automations.tsx
+++ b/src/pages/Automations.tsx
@@ -537,7 +537,7 @@ function renderActionFields(
             onChange={(webhook_key) => onChange({ ...action, webhook_key })}
           />
           <TextInput
-            value={action.message}
+            value={action.message ?? ''}
             placeholder="{user} triggered an event"
             onChange={(message) => onChange({ ...action, message })}
           />

--- a/src/pages/Webhooks.tsx
+++ b/src/pages/Webhooks.tsx
@@ -1,0 +1,762 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useConfirm } from '../components/ConfirmProvider';
+import { PlusIcon, TrashIcon } from '../components/Icons';
+import { interpolate } from '../lib/interpolate';
+import { invoke, tryInvoke } from '../lib/ipc';
+import type {
+  DiscordEmbed,
+  DiscordEmbedField,
+  EmbedTemplate,
+} from '../lib/types';
+
+interface WebhookEntry {
+  key: string;
+  url: string;
+}
+
+const PREVIEW_VARS: Record<string, string | number> = {
+  user: 'PreviewUser',
+  event: 'follow',
+  level: 12,
+  raid_viewers: 42,
+  bits: 500,
+  tier: '1000',
+  total: 5,
+};
+
+const DEFAULT_EMBED: DiscordEmbed = {
+  title: '{user} just followed!',
+  description: 'Welcome to the stream — current level **{level}**.',
+  color: 0x9146ff,
+  author: { name: '{user}' },
+  fields: [],
+  footer: { text: 'TwitchBot' },
+  timestamp: true,
+};
+
+export function Webhooks() {
+  const confirm = useConfirm();
+  const [webhooks, setWebhooks] = useState<WebhookEntry[]>([]);
+  const [templates, setTemplates] = useState<EmbedTemplate[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const [w, t] = await Promise.all([
+      tryInvoke<WebhookEntry[]>('discord-webhooks:list'),
+      tryInvoke<EmbedTemplate[]>('webhooks:getTemplates'),
+    ]);
+    if (w.success) setWebhooks(w.data);
+    else setError(w.error);
+    if (t.success) setTemplates(t.data);
+    else setError(t.error);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const flashNotice = (msg: string) => {
+    setNotice(msg);
+    window.setTimeout(() => setNotice(null), 2500);
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-6 p-6">
+      <div>
+        <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-text">
+          Webhooks
+        </h2>
+        <p className="text-xs text-text-dim">
+          Manage Discord webhook URLs and design rich embed templates.
+        </p>
+      </div>
+
+      {error && (
+        <div className="border border-offline/40 bg-offline/10 px-3 py-2 text-xs text-offline">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="border border-accent/40 bg-accent/10 px-3 py-2 text-xs text-accent">
+          {notice}
+        </div>
+      )}
+
+      <WebhookManager
+        webhooks={webhooks}
+        onChange={refresh}
+        onError={setError}
+        onNotice={flashNotice}
+      />
+
+      <EmbedTemplateSection
+        templates={templates}
+        webhooks={webhooks}
+        confirm={confirm}
+        onChange={refresh}
+        onError={setError}
+        onNotice={flashNotice}
+      />
+    </div>
+  );
+}
+
+// ── Section 1: Webhook URL manager ──────────────────────────────────────────
+
+function WebhookManager({
+  webhooks,
+  onChange,
+  onError,
+  onNotice,
+}: {
+  webhooks: WebhookEntry[];
+  onChange: () => Promise<void>;
+  onError: (msg: string | null) => void;
+  onNotice: (msg: string) => void;
+}) {
+  const [key, setKey] = useState('');
+  const [url, setUrl] = useState('');
+
+  const save = async () => {
+    onError(null);
+    try {
+      await invoke('discord-webhooks:save', { key, url });
+      setKey('');
+      setUrl('');
+      await onChange();
+      onNotice('Webhook saved.');
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Save failed.');
+    }
+  };
+
+  const remove = async (entry: WebhookEntry) => {
+    onError(null);
+    try {
+      await invoke('discord-webhooks:delete', entry.key);
+      await onChange();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Delete failed.');
+    }
+  };
+
+  const test = async (entry: WebhookEntry) => {
+    onError(null);
+    try {
+      await invoke('discord-webhooks:test', { key: entry.key });
+      onNotice(`Test sent to ${entry.key}.`);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Test failed.');
+    }
+  };
+
+  return (
+    <section className="border border-border bg-bg-panel">
+      <header className="border-b border-border px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+        Webhook URLs
+      </header>
+      <div className="space-y-3 p-4">
+        <div className="grid grid-cols-[160px_1fr_auto] gap-2">
+          <input
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            placeholder="name (e.g. raids)"
+            className="border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+          />
+          <input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://discord.com/api/webhooks/…"
+            className="border border-border bg-bg px-2.5 py-1.5 font-mono text-xs text-text outline-none focus:border-accent"
+          />
+          <button
+            onClick={() => {
+              void save();
+            }}
+            disabled={!key.trim() || !url.trim()}
+            className="flex items-center gap-2 border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20 disabled:opacity-50"
+          >
+            <PlusIcon width={14} height={14} />
+            Save
+          </button>
+        </div>
+
+        {webhooks.length === 0 ? (
+          <div className="border border-border bg-bg px-4 py-6 text-center text-xs text-text-dim">
+            No webhooks yet. Add one above.
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {webhooks.map((entry) => (
+              <div
+                key={entry.key}
+                className="grid grid-cols-[160px_1fr_auto_auto] items-center gap-2 border border-border bg-bg px-3 py-2"
+              >
+                <span className="font-mono text-xs text-text">{entry.key}</span>
+                <span className="truncate font-mono text-[11px] text-text-muted">
+                  {maskUrl(entry.url)}
+                </span>
+                <button
+                  onClick={() => {
+                    void test(entry);
+                  }}
+                  className="border border-border bg-bg-panel px-2.5 py-1 text-[10px] uppercase tracking-wider text-text-muted hover:bg-bg-hover"
+                >
+                  Test
+                </button>
+                <button
+                  onClick={() => {
+                    void remove(entry);
+                  }}
+                  aria-label={`Remove webhook ${entry.key}`}
+                  className="flex h-7 w-7 items-center justify-center border border-border text-text-dim hover:text-offline"
+                >
+                  <TrashIcon width={13} height={13} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function maskUrl(url: string): string {
+  if (url.length <= 60) return url;
+  return `${url.slice(0, 40)}…${url.slice(-12)}`;
+}
+
+// ── Section 2 + 3: Embed template editor + live preview ─────────────────────
+
+function EmbedTemplateSection({
+  templates,
+  webhooks,
+  confirm,
+  onChange,
+  onError,
+  onNotice,
+}: {
+  templates: EmbedTemplate[];
+  webhooks: WebhookEntry[];
+  confirm: ReturnType<typeof useConfirm>;
+  onChange: () => Promise<void>;
+  onError: (msg: string | null) => void;
+  onNotice: (msg: string) => void;
+}) {
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState('');
+  const [embed, setEmbed] = useState<DiscordEmbed>(DEFAULT_EMBED);
+  const [testWebhookKey, setTestWebhookKey] = useState('');
+
+  useEffect(() => {
+    if (webhooks.length > 0 && !testWebhookKey) {
+      setTestWebhookKey(webhooks[0].key);
+    }
+  }, [webhooks, testWebhookKey]);
+
+  const loadTemplate = (template: EmbedTemplate) => {
+    setSelectedName(template.name);
+    setDraftName(template.name);
+    setEmbed({
+      title: '',
+      description: '',
+      ...template.embed,
+      author: template.embed.author ?? { name: '' },
+      thumbnail: template.embed.thumbnail ?? { url: '' },
+      footer: template.embed.footer ?? { text: '' },
+      fields: template.embed.fields ?? [],
+    });
+  };
+
+  const newTemplate = () => {
+    setSelectedName(null);
+    setDraftName('');
+    setEmbed(DEFAULT_EMBED);
+  };
+
+  const save = async () => {
+    onError(null);
+    try {
+      await invoke('webhooks:saveTemplate', { name: draftName, embed });
+      await onChange();
+      setSelectedName(draftName.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '_'));
+      onNotice('Template saved.');
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Save failed.');
+    }
+  };
+
+  const remove = async () => {
+    if (!selectedName) return;
+    const ok = await confirm({
+      title: 'Delete template',
+      message: (
+        <>
+          Permanently delete <span className="font-mono text-text">{selectedName}</span>?
+        </>
+      ),
+      confirmLabel: 'Delete',
+      tone: 'danger',
+    });
+    if (!ok) return;
+    onError(null);
+    try {
+      await invoke('webhooks:deleteTemplate', selectedName);
+      await onChange();
+      newTemplate();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Delete failed.');
+    }
+  };
+
+  const sendTest = async () => {
+    onError(null);
+    try {
+      if (!testWebhookKey) throw new Error('Pick a webhook first.');
+      await invoke('webhooks:testEmbed', {
+        webhook_key: testWebhookKey,
+        embed,
+      });
+      onNotice(`Test embed sent via ${testWebhookKey}.`);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Test failed.');
+    }
+  };
+
+  return (
+    <div className="grid min-h-0 gap-4 lg:grid-cols-[260px_1fr_360px]">
+      {/* Template list */}
+      <section className="border border-border bg-bg-panel">
+        <header className="flex items-center justify-between border-b border-border px-3 py-2">
+          <span className="font-mono text-[10px] uppercase tracking-wider text-text-dim">
+            Templates
+          </span>
+          <button
+            onClick={newTemplate}
+            aria-label="New template"
+            className="flex h-6 w-6 items-center justify-center border border-border text-text-muted hover:bg-bg-hover hover:text-text"
+          >
+            <PlusIcon width={12} height={12} />
+          </button>
+        </header>
+        <div className="space-y-0.5 p-2">
+          {templates.length === 0 && (
+            <div className="px-2 py-3 text-xs text-text-dim">No templates yet.</div>
+          )}
+          {templates.map((template) => (
+            <button
+              key={template.name}
+              onClick={() => loadTemplate(template)}
+              className={`block w-full truncate border-l-2 px-2 py-1.5 text-left text-xs ${
+                selectedName === template.name
+                  ? 'border-accent bg-accent/5 text-text'
+                  : 'border-transparent text-text-muted hover:bg-bg-hover hover:text-text'
+              }`}
+            >
+              <span className="font-mono">{template.name}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Editor */}
+      <section className="border border-border bg-bg-panel">
+        <header className="border-b border-border px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+          {selectedName ? `Editing ${selectedName}` : 'New template'}
+        </header>
+        <div className="space-y-4 p-4">
+          <Field label="Template name">
+            <input
+              value={draftName}
+              onChange={(e) => setDraftName(e.target.value)}
+              placeholder="raid-alert"
+              className="w-full border border-border bg-bg px-2.5 py-1.5 font-mono text-sm text-text outline-none focus:border-accent"
+            />
+          </Field>
+
+          <EmbedFields embed={embed} onChange={setEmbed} />
+
+          <div className="border-t border-border pt-3">
+            <Field label="Send test via">
+              <div className="grid grid-cols-[1fr_auto_auto] gap-2">
+                <select
+                  value={testWebhookKey}
+                  onChange={(e) => setTestWebhookKey(e.target.value)}
+                  disabled={webhooks.length === 0}
+                  className="border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent disabled:opacity-50"
+                >
+                  {webhooks.length === 0 ? (
+                    <option>(no webhooks)</option>
+                  ) : (
+                    webhooks.map((w) => (
+                      <option key={w.key} value={w.key}>
+                        {w.key}
+                      </option>
+                    ))
+                  )}
+                </select>
+                <button
+                  onClick={() => {
+                    void sendTest();
+                  }}
+                  disabled={webhooks.length === 0}
+                  className="border border-border bg-bg-panel px-3 py-1.5 text-xs uppercase tracking-wider text-text-muted hover:bg-bg-hover disabled:opacity-50"
+                >
+                  Test embed
+                </button>
+                <button
+                  onClick={() => {
+                    void save();
+                  }}
+                  disabled={!draftName.trim()}
+                  className="border border-accent bg-accent/10 px-3 py-1.5 text-xs uppercase tracking-wider text-accent hover:bg-accent/20 disabled:opacity-50"
+                >
+                  Save
+                </button>
+              </div>
+            </Field>
+            {selectedName && (
+              <button
+                onClick={() => {
+                  void remove();
+                }}
+                className="mt-3 text-xs text-offline hover:underline"
+              >
+                Delete template
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* Live preview */}
+      <section className="border border-border bg-bg-panel">
+        <header className="border-b border-border px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+          Live preview
+        </header>
+        <div className="p-4">
+          <DiscordPreview embed={embed} vars={PREVIEW_VARS} />
+          <div className="mt-3 text-[10px] text-text-dim">
+            Variables: {'{user} {event} {level} {raid_viewers} {bits} {tier} {total}'}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ── Embed editor fields ──
+
+function EmbedFields({
+  embed,
+  onChange,
+}: {
+  embed: DiscordEmbed;
+  onChange: (next: DiscordEmbed) => void;
+}) {
+  const update = (patch: Partial<DiscordEmbed>) => onChange({ ...embed, ...patch });
+
+  const updateAuthor = (patch: Partial<NonNullable<DiscordEmbed['author']>>) => {
+    onChange({
+      ...embed,
+      author: { name: '', ...embed.author, ...patch },
+    });
+  };
+
+  const updateThumbnail = (url: string) => {
+    onChange({ ...embed, thumbnail: { url } });
+  };
+
+  const updateFooter = (text: string) => {
+    onChange({ ...embed, footer: { text } });
+  };
+
+  const updateField = (index: number, patch: Partial<DiscordEmbedField>) => {
+    const fields = [...(embed.fields ?? [])];
+    const current = fields[index];
+    if (!current) return;
+    fields[index] = { ...current, ...patch };
+    onChange({ ...embed, fields });
+  };
+
+  const addField = () => {
+    onChange({
+      ...embed,
+      fields: [...(embed.fields ?? []), { name: '', value: '', inline: false }],
+    });
+  };
+
+  const removeField = (index: number) => {
+    onChange({
+      ...embed,
+      fields: (embed.fields ?? []).filter((_, i) => i !== index),
+    });
+  };
+
+  const colorHex = useMemo(
+    () => `#${(embed.color ?? 0).toString(16).padStart(6, '0').slice(0, 6)}`,
+    [embed.color],
+  );
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Title">
+          <input
+            value={embed.title ?? ''}
+            onChange={(e) => update({ title: e.target.value })}
+            className="w-full border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+          />
+        </Field>
+        <Field label="Color">
+          <div className="grid grid-cols-[44px_1fr] gap-2">
+            <input
+              type="color"
+              value={colorHex}
+              onChange={(e) =>
+                update({ color: parseInt(e.target.value.slice(1), 16) })
+              }
+              className="h-[34px] w-full border border-border bg-bg p-0.5"
+            />
+            <input
+              value={colorHex}
+              onChange={(e) => {
+                const hex = e.target.value.replace('#', '').padStart(6, '0').slice(0, 6);
+                const parsed = parseInt(hex, 16);
+                if (Number.isFinite(parsed)) update({ color: parsed });
+              }}
+              className="w-full border border-border bg-bg px-2.5 py-1.5 font-mono text-sm text-text outline-none focus:border-accent"
+            />
+          </div>
+        </Field>
+      </div>
+
+      <Field label="Description">
+        <textarea
+          value={embed.description ?? ''}
+          onChange={(e) => update({ description: e.target.value })}
+          rows={3}
+          className="w-full resize-none border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Author name">
+          <input
+            value={embed.author?.name ?? ''}
+            onChange={(e) => updateAuthor({ name: e.target.value })}
+            className="w-full border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+          />
+        </Field>
+        <Field label="Author icon URL">
+          <input
+            value={embed.author?.icon_url ?? ''}
+            onChange={(e) => updateAuthor({ icon_url: e.target.value })}
+            className="w-full border border-border bg-bg px-2.5 py-1.5 font-mono text-xs text-text outline-none focus:border-accent"
+          />
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Thumbnail URL">
+          <input
+            value={embed.thumbnail?.url ?? ''}
+            onChange={(e) => updateThumbnail(e.target.value)}
+            className="w-full border border-border bg-bg px-2.5 py-1.5 font-mono text-xs text-text outline-none focus:border-accent"
+          />
+        </Field>
+        <Field label="Footer text">
+          <input
+            value={embed.footer?.text ?? ''}
+            onChange={(e) => updateFooter(e.target.value)}
+            className="w-full border border-border bg-bg px-2.5 py-1.5 text-sm text-text outline-none focus:border-accent"
+          />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-2 text-xs text-text-muted">
+        <input
+          type="checkbox"
+          checked={Boolean(embed.timestamp)}
+          onChange={(e) => update({ timestamp: e.target.checked })}
+          className="h-3.5 w-3.5 accent-accent"
+        />
+        Include timestamp
+      </label>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between border-b border-border pb-1">
+          <span className="font-mono text-[10px] uppercase tracking-wider text-text-dim">
+            Fields
+          </span>
+          <button
+            type="button"
+            onClick={addField}
+            className="border border-border bg-bg px-2 py-1 text-[10px] uppercase tracking-wider text-text-muted hover:bg-bg-hover"
+          >
+            Add field
+          </button>
+        </div>
+        {(embed.fields ?? []).map((field, index) => (
+          <div
+            key={index}
+            className="grid grid-cols-[1fr_2fr_60px_28px] items-center gap-2"
+          >
+            <input
+              value={field.name}
+              placeholder="Name"
+              onChange={(e) => updateField(index, { name: e.target.value })}
+              className="border border-border bg-bg px-2 py-1.5 text-xs text-text outline-none focus:border-accent"
+            />
+            <input
+              value={field.value}
+              placeholder="Value"
+              onChange={(e) => updateField(index, { value: e.target.value })}
+              className="border border-border bg-bg px-2 py-1.5 text-xs text-text outline-none focus:border-accent"
+            />
+            <label className="flex items-center gap-1 text-[10px] text-text-muted">
+              <input
+                type="checkbox"
+                checked={Boolean(field.inline)}
+                onChange={(e) => updateField(index, { inline: e.target.checked })}
+                className="h-3 w-3 accent-accent"
+              />
+              inline
+            </label>
+            <button
+              type="button"
+              onClick={() => removeField(index)}
+              aria-label={`Remove field ${index + 1}`}
+              className="flex h-8 w-7 items-center justify-center border border-border text-text-dim hover:text-offline"
+            >
+              <TrashIcon width={13} height={13} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+// ── Discord-style preview ──
+
+function DiscordPreview({
+  embed,
+  vars,
+}: {
+  embed: DiscordEmbed;
+  vars: Record<string, string | number>;
+}) {
+  const colorBar = useMemo(
+    () => `#${(embed.color ?? 0x202225).toString(16).padStart(6, '0').slice(0, 6)}`,
+    [embed.color],
+  );
+
+  const title = embed.title ? interpolate(embed.title, vars) : '';
+  const description = embed.description ? interpolate(embed.description, vars) : '';
+  const authorName = embed.author?.name ? interpolate(embed.author.name, vars) : '';
+  const authorIcon = embed.author?.icon_url
+    ? interpolate(embed.author.icon_url, vars)
+    : '';
+  const thumbUrl = embed.thumbnail?.url ? interpolate(embed.thumbnail.url, vars) : '';
+  const footerText = embed.footer?.text ? interpolate(embed.footer.text, vars) : '';
+  const fields = (embed.fields ?? []).map((field) => ({
+    name: interpolate(field.name, vars),
+    value: interpolate(field.value, vars),
+    inline: Boolean(field.inline),
+  }));
+  const timestamp = embed.timestamp ? new Date().toLocaleString() : '';
+  const footerLine = [footerText, timestamp].filter(Boolean).join(' • ');
+
+  const inlineFields = fields.filter((f) => f.inline);
+  const blockFields = fields.filter((f) => !f.inline);
+
+  return (
+    <div className="bg-[#36393f] p-3 text-[#dcddde]">
+      <div className="flex">
+        <div
+          className="w-1 shrink-0"
+          style={{ backgroundColor: colorBar, borderRadius: 2 }}
+        />
+        <div className="flex min-w-0 flex-1 gap-3 bg-[#2f3136] p-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            {(authorName || authorIcon) && (
+              <div className="flex items-center gap-2 text-[12px] font-medium">
+                {authorIcon && (
+                  <img
+                    src={authorIcon}
+                    alt=""
+                    className="h-5 w-5 rounded-full object-cover"
+                    onError={(e) => {
+                      e.currentTarget.style.display = 'none';
+                    }}
+                  />
+                )}
+                <span>{authorName}</span>
+              </div>
+            )}
+            {title && (
+              <div className="text-[15px] font-semibold text-white">{title}</div>
+            )}
+            {description && (
+              <div className="whitespace-pre-wrap break-words text-[14px] leading-snug">
+                {description}
+              </div>
+            )}
+
+            {inlineFields.length > 0 && (
+              <div className="grid grid-cols-3 gap-3 pt-1">
+                {inlineFields.map((field, i) => (
+                  <div key={i} className="min-w-0">
+                    <div className="text-[12px] font-semibold text-white">
+                      {field.name}
+                    </div>
+                    <div className="break-words text-[13px] text-[#dcddde]">
+                      {field.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {blockFields.map((field, i) => (
+              <div key={`b${i}`} className="pt-1">
+                <div className="text-[12px] font-semibold text-white">{field.name}</div>
+                <div className="whitespace-pre-wrap break-words text-[13px] text-[#dcddde]">
+                  {field.value}
+                </div>
+              </div>
+            ))}
+
+            {footerLine && (
+              <div className="pt-2 text-[11px] text-[#a3a6aa]">{footerLine}</div>
+            )}
+          </div>
+
+          {thumbUrl && (
+            <img
+              src={thumbUrl}
+              alt=""
+              className="h-20 w-20 shrink-0 rounded object-cover"
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── small primitives ──
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs text-text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/pages/Webhooks.tsx
+++ b/src/pages/Webhooks.tsx
@@ -16,23 +16,84 @@ interface WebhookEntry {
 
 const PREVIEW_VARS: Record<string, string | number> = {
   user: 'PreviewUser',
-  event: 'follow',
-  level: 12,
+  event: 'raid',
+  raider: 'PreviewUser',
+  raid_size: 42,
   raid_viewers: 42,
-  bits: 500,
+  from_channel: 'previewuser',
   tier: '1000',
+  tier_label: 'Tier 1',
+  months: 6,
+  is_gift: 'no',
+  is_anonymous: 'no',
   total: 5,
+  sub_message: 'thanks for the stream!',
+  bits: 500,
+  cheer_message: 'cheer500 amazing!',
+  timestamp: new Date().toLocaleString(),
 };
 
 const DEFAULT_EMBED: DiscordEmbed = {
-  title: '{user} just followed!',
-  description: 'Welcome to the stream — current level **{level}**.',
+  title: '{raider} is raiding with {raid_size}!',
+  description: 'Incoming from **{raider}** — bringing **{raid_size}** viewers.',
   color: 0x9146ff,
-  author: { name: '{user}' },
-  fields: [],
+  author: { name: '{raider}' },
+  fields: [
+    { name: 'Raid size', value: '{raid_size}', inline: true },
+    { name: 'From', value: '{from_channel}', inline: true },
+  ],
   footer: { text: 'TwitchBot' },
   timestamp: true,
 };
+
+interface VarGroup {
+  label: string;
+  events: string;
+  vars: Array<[string, string]>;
+}
+
+const VARIABLE_GROUPS: VarGroup[] = [
+  {
+    label: 'Always',
+    events: 'every event',
+    vars: [
+      ['user', 'Display name of the triggering user (or raider for raids)'],
+      ['event', 'Event type (e.g. follow, raid, cheer)'],
+      ['timestamp', 'ISO timestamp of the event'],
+    ],
+  },
+  {
+    label: 'Raid',
+    events: 'raid',
+    vars: [
+      ['raider', 'Display name of the channel raiding in'],
+      ['raid_size', 'Number of incoming viewers'],
+      ['raid_viewers', 'Alias of raid_size (legacy)'],
+      ['from_channel', 'Login name of the raiding channel'],
+    ],
+  },
+  {
+    label: 'Subscription',
+    events: 'subscription, sub_gift',
+    vars: [
+      ['tier', 'Raw tier code (1000, 2000, 3000, prime)'],
+      ['tier_label', 'Friendly label (Tier 1, Prime, …)'],
+      ['months', 'Cumulative months subscribed'],
+      ['is_gift', '"yes" if this sub was gifted'],
+      ['is_anonymous', '"yes" for anonymous gift subs'],
+      ['total', 'Total subs in a sub_gift bomb'],
+      ['sub_message', 'Resub message text (if any)'],
+    ],
+  },
+  {
+    label: 'Cheer',
+    events: 'cheer',
+    vars: [
+      ['bits', 'Bit count'],
+      ['cheer_message', 'Cheer message text'],
+    ],
+  },
+];
 
 export function Webhooks() {
   const confirm = useConfirm();
@@ -438,9 +499,7 @@ function EmbedTemplateSection({
         </header>
         <div className="p-4">
           <DiscordPreview embed={embed} vars={PREVIEW_VARS} />
-          <div className="mt-3 text-[10px] text-text-dim">
-            Variables: {'{user} {event} {level} {raid_viewers} {bits} {tier} {total}'}
-          </div>
+          <VariableReference />
         </div>
       </section>
     </div>
@@ -746,6 +805,34 @@ function DiscordPreview({
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+// ── variable reference card ──
+
+function VariableReference() {
+  return (
+    <div className="mt-4 space-y-3 border-t border-border pt-3">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-text-dim">
+        Available variables
+      </div>
+      {VARIABLE_GROUPS.map((group) => (
+        <div key={group.label}>
+          <div className="mb-1 flex items-baseline justify-between">
+            <span className="text-[11px] font-semibold text-text">{group.label}</span>
+            <span className="font-mono text-[10px] text-text-dim">{group.events}</span>
+          </div>
+          <div className="space-y-0.5">
+            {group.vars.map(([name, desc]) => (
+              <div key={name} className="grid grid-cols-[120px_1fr] gap-2">
+                <code className="font-mono text-[11px] text-accent">{`{${name}}`}</code>
+                <span className="text-[11px] text-text-muted">{desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Closes #18

## Summary
- Adds an optional `embed` object to the `send_discord_webhook` automation action (title, description, color, author, thumbnail, fields, footer, timestamp). The send path builds Discord's `embeds[]` payload with template-variable resolution on every string field, falling back to `{ content }` when no embed is set.
- New `electron/services/discord-webhooks.ts` centralises URL CRUD, embed-template CRUD, and the payload builder. The pre-existing `discord-webhooks:*` IPC handlers now route through it (single source of truth for `normalizeWebhookKey`).
- Embed templates persist in `settings` keyed `discord_embed_template_<name>` (JSON). Added the prefix to `settings-service`'s allowlist.
- New IPC handlers: `webhooks:getTemplates`, `webhooks:saveTemplate`, `webhooks:deleteTemplate`, `webhooks:testEmbed`.
- New `src/pages/Webhooks.tsx` with three sections: webhook URL manager (list/save/delete/test), template editor with all embed fields, and a live Discord-style preview that renders as you type. Supports `{user} {event} {level} {raid_viewers} {bits} {tier} {total}` placeholders.
- Sidebar entry, `/webhooks` route, and Alt+7 nav hotkey. Removed the now-stale `Alt+9 → /moderation?tab=logs` mapping (the Moderation page still owns its own tab state).

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` (48 tests) passes
- [x] `npm run build` (vite + tsc) succeeds
- [ ] Manual: launch app → /webhooks → add a webhook URL → click Test → verify Discord receives `TwitchBot webhook test`
- [ ] Manual: edit a template → toggle fields/colors/timestamp → confirm preview matches Discord's render
- [ ] Manual: pick a webhook in the editor's "Send test via" → click Test embed → verify rich embed lands in Discord with mock variables resolved
- [ ] Manual: save a template, reload app, confirm it persists in the list
- [ ] Manual: in Automations editor, add a `send_discord_webhook` action with the existing message-only flow → confirm it still sends `{ content }` to Discord (backwards compatibility)

> Substantive UI change — preview/test before squash-merge.