### PR TITLE
security: harden IPC, webhooks, auth, transactions, cooldowns, error handling

### DIFF
--- a/electron/ipc/automations.ts
+++ b/electron/ipc/automations.ts
@@ -18,6 +18,7 @@ import {
   getWebhookUrl,
   listWebhooks,
   saveWebhook,
+  testWebhookUrl,
 } from '../services/discord-webhooks';
 
 type IpcResult<T> = { success: true; data: T } | { success: false; error: string };
@@ -113,14 +114,7 @@ export function registerAutomationHandlers(): void {
       try {
         const url = payload.url ?? getWebhookUrl(payload.key);
         if (!url) throw new Error('Webhook URL is empty.');
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: 'TwitchBot webhook test' }),
-        });
-        if (!res.ok) {
-          throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
-        }
+        await testWebhookUrl(url);
         return ok(null);
       } catch (err) {
         return fail(err);

--- a/electron/ipc/window.ts
+++ b/electron/ipc/window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain, shell } from 'electron';
 import path from 'node:path';
+import { isSafeExternalUrl } from '../lib/url-security';
 
 type IpcResult<T> = { success: true; data: T } | { success: false; error: string };
 
@@ -66,7 +67,11 @@ export function registerWindowHandlers(): void {
       void win.loadURL(buildPopoutUrl(payload.route));
 
       win.webContents.setWindowOpenHandler(({ url: outUrl }) => {
-        shell.openExternal(outUrl);
+        if (isSafeExternalUrl(outUrl)) {
+          void shell.openExternal(outUrl);
+        } else {
+          console.warn(`[window] blocked external URL: ${outUrl}`);
+        }
         return { action: 'deny' };
       });
 

--- a/electron/lib/url-security.ts
+++ b/electron/lib/url-security.ts
@@ -1,0 +1,74 @@
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+export function isSafeExternalUrl(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:') return false;
+
+  const host = parsed.hostname.toLowerCase();
+  if (LOCAL_HOSTS.has(host) || host.endsWith('.localhost')) return false;
+  if (isPrivateIp(host)) return false;
+
+  return true;
+}
+
+export function validateDiscordWebhookUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error('Discord webhook URL is invalid.');
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const allowedHost = host === 'discord.com' || host === 'discordapp.com';
+  if (
+    parsed.protocol !== 'https:' ||
+    !allowedHost ||
+    !parsed.pathname.startsWith('/api/webhooks/')
+  ) {
+    throw new Error('Discord webhook URL must be a Discord API webhook URL.');
+  }
+
+  return parsed.toString();
+}
+
+function isPrivateIp(host: string): boolean {
+  if (isPrivateIpv4(host)) return true;
+  return isPrivateIpv6(host.replace(/^\[|\]$/g, ''));
+}
+
+function isPrivateIpv4(host: string): boolean {
+  const parts = host.split('.');
+  if (parts.length !== 4) return false;
+  const nums = parts.map((part) => Number(part));
+  if (nums.some((n, i) => !Number.isInteger(n) || n < 0 || n > 255 || String(n) !== parts[i])) {
+    return false;
+  }
+
+  const [a, b] = nums as [number, number, number, number];
+  return (
+    a === 10 ||
+    a === 127 ||
+    a === 0 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
+function isPrivateIpv6(host: string): boolean {
+  const normalized = host.toLowerCase();
+  if (!normalized.includes(':')) return false;
+  return (
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe80:')
+  );
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -24,6 +24,7 @@ import { loadCredentialsFromDisk } from './services/credentials';
 import { closeDanglingSession } from './services/streak-tracker';
 import { loadTokensFromDisk } from './services/twitch-auth';
 import { disconnectBot } from './services/twitch-chat';
+import { isSafeExternalUrl } from './lib/url-security';
 
 dotenv.config({ path: path.join(app.getAppPath(), '.env') });
 
@@ -31,6 +32,14 @@ const isDev = process.env.NODE_ENV === 'development';
 const DEV_URL = 'http://localhost:5173';
 
 let mainWindow: BrowserWindow | null = null;
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[process] unhandled rejection:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('[process] uncaught exception:', err);
+});
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -55,7 +64,11 @@ function createWindow(): void {
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isSafeExternalUrl(url)) {
+      void shell.openExternal(url);
+    } else {
+      console.warn(`[window] blocked external URL: ${url}`);
+    }
     return { action: 'deny' };
   });
 

--- a/electron/services/automation-engine.ts
+++ b/electron/services/automation-engine.ts
@@ -290,6 +290,9 @@ async function executeAutomation(
   automation: AutomationRow,
   ctx: AutomationContext,
 ): Promise<void> {
+  const triggeredAt = reserveAutomationCooldown(automation);
+  if (triggeredAt === null) return;
+
   for (const action of automation.actions) {
     try {
       await executeAction(action, ctx);
@@ -297,12 +300,26 @@ async function executeAutomation(
       console.error(`[auto] action ${action.type} failed:`, err);
     }
   }
+  automation.last_triggered_at = triggeredAt;
+  broadcast('automations:triggered', { id: automation.id, timestamp: triggeredAt });
+}
+
+function reserveAutomationCooldown(automation: AutomationRow): number | null {
   const now = Math.floor(Date.now() / 1000);
-  getDatabase()
-    .prepare('UPDATE automations SET last_triggered_at = ?, updated_at = unixepoch() WHERE id = ?')
-    .run(now, automation.id);
-  automation.last_triggered_at = now;
-  broadcast('automations:triggered', { id: automation.id, timestamp: now });
+  const info = getDatabase()
+    .prepare(
+      `UPDATE automations
+       SET last_triggered_at = ?, updated_at = unixepoch()
+       WHERE id = ?
+         AND (
+           cooldown_seconds <= 0
+           OR last_triggered_at IS NULL
+           OR ? - last_triggered_at >= cooldown_seconds
+         )`,
+    )
+    .run(now, automation.id, now);
+  if (info.changes === 0) return null;
+  return now;
 }
 
 async function executeAction(

--- a/electron/services/bot-events.ts
+++ b/electron/services/bot-events.ts
@@ -57,7 +57,13 @@ export function emitBotEvent<K extends BotEventName>(
   event: K,
   payload: BotEventMap[K],
 ): void {
-  emitter.emit(event, payload);
+  for (const listener of emitter.listeners(event)) {
+    try {
+      (listener as BotEventHandler<K>)(payload);
+    } catch (err) {
+      console.error(`[bot-events] ${String(event)} listener failed:`, err);
+    }
+  }
 }
 
 export function onBotEvent<K extends BotEventName>(

--- a/electron/services/discord-webhooks.ts
+++ b/electron/services/discord-webhooks.ts
@@ -4,6 +4,7 @@
  */
 
 import { interpolate } from '../lib/command-logic';
+import { validateDiscordWebhookUrl } from '../lib/url-security';
 import { deleteSetting, getAllSettings, getSetting, updateSetting } from './settings-service';
 
 export interface DiscordEmbedField {
@@ -37,6 +38,7 @@ export type TemplateVars = Record<string, string | number>;
 
 const WEBHOOK_PREFIX = 'discord_webhook_';
 const TEMPLATE_PREFIX = 'discord_embed_template_';
+const WEBHOOK_TIMEOUT_MS = 10_000;
 
 export function normalizeWebhookKey(key: string): string {
   const normalized = key
@@ -72,7 +74,7 @@ export function listWebhooks(): Array<{ key: string; url: string }> {
 
 export function saveWebhook(key: string, url: string): void {
   const normalized = normalizeWebhookKey(key);
-  updateSetting(`${WEBHOOK_PREFIX}${normalized}`, url);
+  updateSetting(`${WEBHOOK_PREFIX}${normalized}`, validateDiscordWebhookUrl(url));
 }
 
 export function deleteWebhook(key: string): void {
@@ -141,6 +143,10 @@ export async function testEmbed(
   await postToUrl(url, { embed }, vars);
 }
 
+export async function testWebhookUrl(url: string): Promise<void> {
+  await postToUrl(url, { content: 'TwitchBot webhook test' }, {});
+}
+
 export function buildPayload(
   options: SendOptions,
   vars: TemplateVars,
@@ -180,17 +186,25 @@ async function postToUrl(
   options: SendOptions,
   vars: TemplateVars,
 ): Promise<void> {
+  const safeUrl = validateDiscordWebhookUrl(url);
   const payload = buildPayload(options, vars);
   if (!payload.content && !payload.embeds) {
     throw new Error('Webhook payload is empty.');
   }
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) {
-    throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+  try {
+    const res = await fetch(safeUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+    }
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/electron/services/exp-engine.ts
+++ b/electron/services/exp-engine.ts
@@ -124,11 +124,13 @@ export function awardExp(
   const newTotal = user.exp + amount;
   const newLevel = computeLevel(newTotal, settings.levelBase, settings.levelExponent);
 
-  getDatabase()
-    .prepare('UPDATE users SET exp = ?, level = ? WHERE twitch_id = ?')
-    .run(newTotal, newLevel, twitchId);
-
-  logEvent(source, twitchId, amount, options.data);
+  const db = getDatabase();
+  const writeAward = db.transaction(() => {
+    db.prepare('UPDATE users SET exp = ?, level = ? WHERE twitch_id = ?')
+      .run(newTotal, newLevel, twitchId);
+    logEvent(source, twitchId, amount, options.data);
+  });
+  writeAward();
 
   if (!options.suppressFeed) {
     broadcast('users:exp-gained', {

--- a/electron/services/twitch-auth.ts
+++ b/electron/services/twitch-auth.ts
@@ -205,11 +205,32 @@ function renderCallbackPage(success: boolean, message?: string): string {
   const body = success
     ? 'You can close this tab and return to TwitchBot.'
     : `Something went wrong: ${message ?? 'unknown error'}. You can close this tab.`;
-  return `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>
+  const safeTitle = escapeHtml(title);
+  const safeBody = escapeHtml(body);
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${safeTitle}</title>
 <style>html,body{height:100%;margin:0;background:#0e0e10;color:#efeff1;font-family:system-ui,sans-serif}
 .wrap{height:100%;display:flex;align-items:center;justify-content:center;flex-direction:column;gap:8px}
 h1{font-size:20px;margin:0}p{color:#adadb8;margin:0}</style></head>
-<body><div class="wrap"><h1>${title}</h1><p>${body}</p></div></body></html>`;
+<body><div class="wrap"><h1>${safeTitle}</h1><p>${safeBody}</p></div></body></html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
 }
 
 async function exchangeCodeForTokens(params: {

--- a/electron/services/users-repo.ts
+++ b/electron/services/users-repo.ts
@@ -167,22 +167,25 @@ export function adjustUserExp(
   const newTotal = Math.max(0, existing.exp + delta);
   const newLevel = computeLevel(newTotal, base, exponent);
 
-  db.prepare('UPDATE users SET exp = ?, level = ? WHERE twitch_id = ?').run(
-    newTotal,
-    newLevel,
-    twitchId,
-  );
+  const writeAdjustment = db.transaction(() => {
+    db.prepare('UPDATE users SET exp = ?, level = ? WHERE twitch_id = ?').run(
+      newTotal,
+      newLevel,
+      twitchId,
+    );
 
-  db.prepare(
-    `INSERT INTO events (type, twitch_user_id, data, exp_awarded, created_at)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(
-    'admin',
-    twitchId,
-    JSON.stringify({ reason: reason ?? null, delta }),
-    delta,
-    new Date().toISOString(),
-  );
+    db.prepare(
+      `INSERT INTO events (type, twitch_user_id, data, exp_awarded, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      'admin',
+      twitchId,
+      JSON.stringify({ reason: reason ?? null, delta }),
+      delta,
+      new Date().toISOString(),
+    );
+  });
+  writeAdjustment();
 
   broadcast('users:exp-gained', {
     user: {


### PR DESCRIPTION
## Summary
- add URL validation for external links and Discord webhooks
- add timeout protection for Discord webhook POSTs
- escape OAuth callback error HTML
- make EXP/event writes transactional and automation cooldown reservation atomic
- isolate bot event listener failures and log global main-process failures

Closes #24

## Validation
- npm run typecheck
- npm test
- npm run test:ipc with ELECTRON_RUN_AS_NODE cleared for Electron