### PR TITLE
perf(users): faster leaderboard via RANK() window + sort indexes

### DIFF
--- a/electron/db/schema.sql
+++ b/electron/db/schema.sql
@@ -19,6 +19,12 @@ CREATE INDEX IF NOT EXISTS idx_users_exp       ON users(exp DESC);
 CREATE INDEX IF NOT EXISTS idx_users_username  ON users(username);
 CREATE INDEX IF NOT EXISTS idx_users_exp_username ON users(exp DESC, username ASC);
 CREATE INDEX IF NOT EXISTS idx_users_last_seen ON users(last_seen DESC);
+-- Composite indexes for the remaining leaderboard sort keys exposed by
+-- listUsers' SORT_COLUMNS, mirroring idx_users_exp_username so the
+-- secondary `username ASC` tiebreaker stays index-served.
+CREATE INDEX IF NOT EXISTS idx_users_level_username      ON users(level              DESC, username ASC);
+CREATE INDEX IF NOT EXISTS idx_users_watch_time_username ON users(watch_time_minutes DESC, username ASC);
+CREATE INDEX IF NOT EXISTS idx_users_messages_username   ON users(messages_sent      DESC, username ASC);
 
 CREATE TABLE IF NOT EXISTS commands (
   id                INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/electron/services/users-repo.ts
+++ b/electron/services/users-repo.ts
@@ -94,8 +94,16 @@ export function listUsers(opts: ListUsersOptions = {}): ListUsersResult {
   const where = searchLike ? 'WHERE username LIKE ?' : '';
   const secondarySort = column === 'username' ? '' : ', username ASC';
 
-  const sql = `SELECT u.*, (SELECT COUNT(*) + 1 FROM users u2 WHERE u2.exp > u.exp) AS rank
-    FROM users u
+  // Compute rank (competition rank, equivalent to the prior
+  // `COUNT(*) + 1 WHERE exp > u.exp` correlated subquery) once over the
+  // full users table via a window function, then filter / sort / paginate
+  // the listed page. Replaces O(N log N) correlated lookups with a single
+  // O(N) window pass over the `idx_users_exp` index.
+  const sql = `WITH ranked AS (
+      SELECT *, RANK() OVER (ORDER BY exp DESC) AS rank FROM users
+    )
+    SELECT *
+    FROM ranked
     ${where}
     ORDER BY ${column} ${direction}${secondarySort}
     LIMIT ? OFFSET ?`;


### PR DESCRIPTION
Closes #34. Audit #26 follow-up — second perf hot spot the prior #29 didn't reach.

## Summary

- `listUsers` no longer runs a correlated subquery per row to compute rank. A CTE wraps the users table with `RANK() OVER (ORDER BY exp DESC)` once, then the outer query filters / sorts / paginates the page.
- Adds composite indexes for the three remaining `SORT_COLUMNS` keys (`level`, `watch_time_minutes`, `messages_sent`) so all six leaderboard sorts are now index-served, including the `username ASC` tiebreaker.

## Why the rank query was slow

The previous form was

```sql
SELECT u.*, (SELECT COUNT(*) + 1 FROM users u2 WHERE u2.exp > u.exp) AS rank
FROM users u …
```

Per row, the correlated subquery does a count over `idx_users_exp` (`O(log N + matches)`); across `LIMIT N` rows it's `O(N log N)` of repeated index work. The CTE form is one window pass over the same index, `O(N)` once, regardless of page size.

## Why I left the single-user lookups alone

`getUserProfile` and `getUserWithRank` use the same correlated subquery, but for a single row that's already an indexed range scan over `idx_users_exp` — one lookup, optimal. Refactoring them to a window function would still scan all users to compute the window, just to discard all but one row. Worse, not better.

## Semantics check

`COUNT(*) + 1 WHERE exp > current` is competition rank: ties share a rank, the next group skips. SQL `RANK()` produces exactly the same numbers. No behavior change for the renderer.

## Indexes added

```sql
CREATE INDEX IF NOT EXISTS idx_users_level_username      ON users(level              DESC, username ASC);
CREATE INDEX IF NOT EXISTS idx_users_watch_time_username ON users(watch_time_minutes DESC, username ASC);
CREATE INDEX IF NOT EXISTS idx_users_messages_username   ON users(messages_sent      DESC, username ASC);
```

Schema runs on every startup with `CREATE INDEX IF NOT EXISTS`, so first launch on this version creates them automatically. No migration script required.

## Verification

```
npm run lint        ✅
npm run typecheck   ✅
npm test            ✅ 55/55
npm run build       ✅
```

Same caveat as #32: vitest covers `electron/lib/*` only — the new SQL has no runtime test coverage. Tracked in #33.

## Test plan

- [x] CI green
- [ ] Smoke: open the leaderboard, sort by each of `exp`, `level`, `watch_time`, `messages`, `username`, `last_seen`, `asc` and `desc`, page through. Rank column should still match exp-order rank regardless of sort.
- [ ] Sanity: confirm the new indexes show in `sqlite_master` after first launch on this build.

## Out of scope (separate issues)

- Generic `invoke/on/off` preload tightening
- `isSafeExternalUrl` host allowlist
- BrowserWindow `sandbox: true`
- `npm audit` to 0
- Branch protection on main