### PR TITLE
fix(release): correct nsis property, bump to 1.1.0, add download docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Moderation Suite v2 ([#21](https://github.com/9ny4/twitchbot/pull/21))
+## [1.1.0] — 2026-07-16
+
+First packaged release: Windows installer built and published via the Release
+workflow (fixed an invalid `nsis` property in `electron-builder.yml` that
+blocked packaging).
+
+### Moderation Suite v2 ([#21](https://github.com/sekkedev/twitchbot/pull/21))
 - Added blocked words rule (case-insensitive substring match against a JSON word list).
 - Added first-message screening that auto-deletes the first chat from any user with `messages_sent = 0` (subscribers exempt).
 - Added per-rule escalation override: `mod_<rule>_start_tier` (1–4) shifts the offence ladder so the first violation can land on any tier.
@@ -16,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Discord webhook alerts for every mod action, dispatched via the seeded `moderation` embed template (editable in the Webhooks page).
 - Rewrote `Moderation.tsx`: stats strip, blocked-words tag input, per-rule start-tier dropdowns, first-message toggle card, Discord alerts section, paginated warnings table with rule filter and Prev/Next.
 
-### Discord Embed Builder ([#19](https://github.com/9ny4/twitchbot/pull/19))
+### Discord Embed Builder ([#19](https://github.com/sekkedev/twitchbot/pull/19))
 - Added Webhooks page with three sections: webhook URL manager, visual embed template editor, and a live Discord-style preview that renders as you type.
 - Extended the `send_discord_webhook` automation action with an optional `embed` (title, description, color, author, thumbnail, fields, footer, timestamp). Plain-text webhooks unchanged.
 - Added embed-template storage and IPC: `webhooks:getTemplates`, `webhooks:saveTemplate`, `webhooks:deleteTemplate`, `webhooks:testEmbed`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Chat commands, EXP and levels, watch streaks, scheduled chat timers, automatic moderation with Helix-backed actions, an automation engine for follows/subs/raids, a live event feed, and a dashboard for the analytics nerd in you. No cloud. No accounts. No subscriptions. Just an app on your PC that talks to Twitch directly.
 
+## Download
+
+Grab the Windows installer (`TwitchBot-x.y.z-setup.exe`) from the
+[latest release](https://github.com/sekkedev/twitchbot/releases/latest) —
+Windows 10/11, no build tools required. You'll still need your own Twitch
+application credentials (see [Getting started](#getting-started), step 1).
+Prefer building from source? That's step 2.
+
 ![Dashboard](docs/screenshots/01-dashboard.png)
 
 ---
@@ -107,7 +115,7 @@ You need your own app on Twitch (takes 2 minutes) — this app doesn't ship with
 Requires Node.js 20+ on Windows 10/11.
 
 ```powershell
-git clone https://github.com/9ny4/twitchbot.git
+git clone https://github.com/sekkedev/twitchbot.git
 cd twitchbot
 npm install
 npm run dev

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,4 +16,4 @@ win:
   artifactName: ${productName}-${version}-setup.${ext}
 nsis:
   oneClick: false
-  allowToChangeInstallationDir: true
+  allowToChangeInstallationDirectory: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twitchbot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twitchbot",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitchbot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Local Windows desktop Twitch bot with loyalty/EXP system",
   "main": "dist-electron/main.js",
   "author": "",


### PR DESCRIPTION
## Problem

Tagging the first release exposed that the Release workflow has never worked: electron-builder 26.8.1 rejects `nsis.allowToChangeInstallationDir` (the valid property is `allowToChangeInstallationDirectory`), so packaging fails before any artifact is built (run 29521429450). Separately, the README had no download path for users and the CHANGELOG carried an Unreleased section larger than the never-shipped 1.0.0.

## Fix

- `electron-builder.yml`: `allowToChangeInstallationDir` -> `allowToChangeInstallationDirectory`
- Version 1.0.0 -> 1.1.0 (`npm version`, package.json + lockfile); Unreleased (Moderation Suite v2, Discord Embed Builder) rolled into `[1.1.0] - 2026-07-16`
- README: new Download section pointing at the latest release; clone URL fixed from `9ny4` to `sekkedev`
- CHANGELOG: stale `9ny4` PR links fixed

## Verification

- Property name checked against the electron-builder 26.8.1 schema error output (valid set includes `allowToChangeInstallationDirectory`)
- `npm version` updated package.json and both lockfile version fields consistently
- Packaging itself is exercised by the Release workflow on the `v1.1.0` tag after merge

Closes #38